### PR TITLE
starting the laser with M3S0 to avoid firing up delays.

### DIFF
--- a/octoprint_mrbeam/gcodegenerator/img2gcode.py
+++ b/octoprint_mrbeam/gcodegenerator/img2gcode.py
@@ -340,7 +340,7 @@ class ImageProcessor():
 		# pre-condition: set feedrate, enable laser with 0 intensity.
 		self._append_gcode('F' + str(self.feedrate_white)) # set an initial feedrate
 		self.gc_ctx.f = self.feedrate_white #TODO hack. set with line above
-		self._append_gcode('M3S0') # enable laser
+		#self._append_gcode('M3S0') # enable laser
 		self.gc_ctx.s = 0 #TODO hack. set with line above
 		self.gc_ctx.laser_active = True #TODO hack. set with line above
 
@@ -363,8 +363,9 @@ class ImageProcessor():
 			img_pos_mm = (x_off, y_off) # lower left corner of partial image in mm
 
 			self._append_gcode("; Begin part {} @ pixel ({},{}) with dimensions {}x{}".format(img_data['id'], img_data['x'],img_data['y'], size[0], size[1]))
-			gc = self._get_gcode_g0(self, x=x_off, y=y_off, comment="; Move to start ({},{})".format(x_off, y_off))
+			gc = self._get_gcode_g0(x=x_off, y=y_off, comment="; Move to start ({},{})".format(x_off, y_off))
 			self._append_gcode(gc)
+			self._append_gcode('M3S0\nG4P0.1') # initialize laser
 			# iterate line by line
 			pix = img.load()
 			for row in range(height_px-1,-1,-1):

--- a/octoprint_mrbeam/gcodegenerator/img2gcode.py
+++ b/octoprint_mrbeam/gcodegenerator/img2gcode.py
@@ -365,7 +365,7 @@ class ImageProcessor():
 			self._append_gcode("; Begin part {} @ pixel ({},{}) with dimensions {}x{}".format(img_data['id'], img_data['x'],img_data['y'], size[0], size[1]))
 			gc = self._get_gcode_g0(x=x_off, y=y_off, comment="; Move to start ({},{})".format(x_off, y_off))
 			self._append_gcode(gc)
-			self._append_gcode('M3S0\nG4P0.1') # initialize laser
+			self._append_gcode('M3S0\nG4P0') # initialize laser
 			# iterate line by line
 			pix = img.load()
 			for row in range(height_px-1,-1,-1):

--- a/octoprint_mrbeam/gcodegenerator/img2gcode.py
+++ b/octoprint_mrbeam/gcodegenerator/img2gcode.py
@@ -363,6 +363,8 @@ class ImageProcessor():
 			img_pos_mm = (x_off, y_off) # lower left corner of partial image in mm
 
 			self._append_gcode("; Begin part {} @ pixel ({},{}) with dimensions {}x{}".format(img_data['id'], img_data['x'],img_data['y'], size[0], size[1]))
+			gc = self._get_gcode_g0(self, x=x_off, y=y_off, comment="; Move to start ({},{})".format(x_off, y_off))
+			self._append_gcode(gc)
 			# iterate line by line
 			pix = img.load()
 			for row in range(height_px-1,-1,-1):
@@ -781,6 +783,7 @@ if __name__ == "__main__":
 		header = ""
 		footer = ""
 		if(options.noheaders == "false"):
+			# TODO get headers from machine_settings.py
 			header = '''
 $H
 G92X0Y0Z0

--- a/octoprint_mrbeam/gcodegenerator/machine_settings.py
+++ b/octoprint_mrbeam/gcodegenerator/machine_settings.py
@@ -1,27 +1,27 @@
-# To change this license header, choose License Headers in Project Properties.
-# To change this template file, choose Tools | Templates
-# and open the template in the editor.
+
 
 
 def gcode_before_path(intensity = 0):
-	return "\nM03 S"+str(intensity)
+	return "\nM3S0\nG4P0.2\nM03 S"+str(intensity)
 
 def gcode_before_path_color(color = '#000000', intensity = '0'):
-	return "\nM03 S%s;%s" % (intensity, color) 
+	return "\nM3S0\nG4P0.2\nM03 S%s;%s" % (intensity, color) 
 
 def gcode_after_path():
 	return "M05"
 
+# TODO remove this or fetch machine settings from settings. (G92 X0 Y0 Z0 looks badly wrong for Mr Beam II machines.)
 gcode_header = """
 $H
-G92 X0 Y0 Z0
+G92 X0 Y0 Z0 
 G90
 M08
 """
 
+# TODO remove this or fetch machine settings from settings.
 gcode_footer = """
 M05
-G0 X500.000 Y400.000
+G0 X500.000 Y390.000
 M09
 M02
 """

--- a/octoprint_mrbeam/gcodegenerator/machine_settings.py
+++ b/octoprint_mrbeam/gcodegenerator/machine_settings.py
@@ -2,10 +2,10 @@
 
 
 def gcode_before_path(intensity = 0):
-	return "\nM3S0\nG4P0.1\nM03 S"+str(intensity)
+	return "\nM3S0\nG4P0\nM03 S"+str(intensity)
 
 def gcode_before_path_color(color = '#000000', intensity = '0'):
-	return "\nM3S0\nG4P0.1\nM03 S%s;%s" % (intensity, color) 
+	return "\nM3S0\nG4P0\nM03 S%s;%s" % (intensity, color) 
 
 def gcode_after_path():
 	return "M05"

--- a/octoprint_mrbeam/gcodegenerator/machine_settings.py
+++ b/octoprint_mrbeam/gcodegenerator/machine_settings.py
@@ -2,10 +2,10 @@
 
 
 def gcode_before_path(intensity = 0):
-	return "\nM3S0\nG4P0.2\nM03 S"+str(intensity)
+	return "\nM3S0\nG4P0.1\nM03 S"+str(intensity)
 
 def gcode_before_path_color(color = '#000000', intensity = '0'):
-	return "\nM3S0\nG4P0.2\nM03 S%s;%s" % (intensity, color) 
+	return "\nM3S0\nG4P0.1\nM03 S%s;%s" % (intensity, color) 
 
 def gcode_after_path():
 	return "M05"


### PR DESCRIPTION
solution uses 200msec pierce time after moving into position before M3S0. Avoids
confusion because no laserdot is visible and is consistent for vector
and raster mode.