### PR TITLE
Fixes error state if flash_grbl failed + analytics: added avrdude output

### DIFF
--- a/octoprint_mrbeam/analytics/analytics_handler.py
+++ b/octoprint_mrbeam/analytics/analytics_handler.py
@@ -65,7 +65,7 @@ class AnalyticsHandler(object):
 		self._storedConversions = list()
 
 		self._jobevent_log_version = 4
-		self._deviceinfo_log_version = 3
+		self._deviceinfo_log_version = 4
 		self._logevent_version = 1
 		self._dust_log_version = 2
 		self._cam_event_log_version = 2
@@ -250,11 +250,12 @@ class AnalyticsHandler(object):
 	def _event_shutdown(self,event,payload):
 		self._write_deviceinfo(ak.SHUTDOWN)
 
-	def write_flash_grbl(self, from_version, to_version, succesful):
+	def write_flash_grbl(self, from_version, to_version, succesful, err=None):
 		payload = dict(
 			from_version=from_version,
 			to_version=to_version,
-			succesful=succesful)
+			succesful=succesful,
+			err=err)
 		self._write_deviceinfo(ak.FLASH_GRBL, payload=payload)
 
 	def _event_ip_addresses(self):

--- a/octoprint_mrbeam/comm_acc2.py
+++ b/octoprint_mrbeam/comm_acc2.py
@@ -1063,20 +1063,17 @@ class MachineCom(object):
 				_mrbeam_plugin_implementation._analytics_handler.write_flash_grbl(
 					from_version=from_version,
 					to_version=grbl_file,
-					succesful=(code == 0))
+					succesful=(code == 0),
+					err = None if (code == 0) else output)
 			except:
 				self._logger.exception("Exception while writing GRBL-flashing to analytics: ")
 
 		# error case
 		if code != 0 and not verify_only:
-			msg_short = "ERROR flashing GRBL '{}'".format(grbl_file)
+			msg_short = "ERROR flashing GRBL '{}': FAILED (See Avrdude output above for details.)".format(grbl_file)
 			msg_long = '{}:\n{}'.format(msg_short, output)
 			self._logger.error(msg_long, terminal_as_comm=True)
 			self._logger.error(msg_short, terminal_as_comm=True)
-			self._errorValue = "avrdude returncode: %s" % code
-			self._changeState(self.STATE_CLOSED_WITH_ERROR)
-			self._logger.info("Please reconnect manually or reboot system.", terminal_as_comm=True)
-			return
 		elif code != 0 and verify_only:
 			msg_short = "Verification GRBL '{}': FAILED (See Avrdude output above for details.)".format(grbl_file)
 			msg_long = '{}:\n{}'.format(msg_short, output)


### PR DESCRIPTION
Analytics changes:
_deviceinfo_log_version: increased to 4
added ‘err’ key to flash_grbl ( write_flash_grbl() ) desc: “Output of avrdude in case of an error.” 