### PR TITLE
Laser param screen: rewording, arrows and smaller details

### DIFF
--- a/octoprint_mrbeam/iobeam/compressor_handler.py
+++ b/octoprint_mrbeam/iobeam/compressor_handler.py
@@ -59,8 +59,7 @@ class CompressorHandler(object):
 		self._event_bus.subscribe(OctoPrintEvents.PRINT_RESUMED, self.set_compressor_unpause)
 
 	def has_compressor(self):
-		# return self._plugin.is_mrbeam2_dreamcut()
-		return True
+		return self._plugin.is_mrbeam2_dreamcut()
 
 	def get_current_state(self):
 		if self.has_compressor():

--- a/octoprint_mrbeam/iobeam/compressor_handler.py
+++ b/octoprint_mrbeam/iobeam/compressor_handler.py
@@ -59,7 +59,8 @@ class CompressorHandler(object):
 		self._event_bus.subscribe(OctoPrintEvents.PRINT_RESUMED, self.set_compressor_unpause)
 
 	def has_compressor(self):
-		return self._plugin.is_mrbeam2_dreamcut()
+		# return self._plugin.is_mrbeam2_dreamcut()
+		return True
 
 	def get_current_state(self):
 		if self.has_compressor():

--- a/octoprint_mrbeam/static/css/svgtogcode.css
+++ b/octoprint_mrbeam/static/css/svgtogcode.css
@@ -351,15 +351,6 @@ h4.job_title{
     text-align: center;
 }
 
-.job_row input[type="number"]::-webkit-inner-spin-button {
-    -webkit-appearance: none;
-    margin: 0;
-}
-
-.job_row input[type="number"].param_passes::-webkit-inner-spin-button {
-    -webkit-appearance: inner-spin-button;
-}
-
 .job_row label.control-label {cursor: default; }
 
 .job_row .form-horizontal .control-group {

--- a/octoprint_mrbeam/static/js/convert.js
+++ b/octoprint_mrbeam/static/js/convert.js
@@ -1616,7 +1616,7 @@ window.mrbeam.colorDragging = {
 			newJob.attr('id', '');
 			var i = $('.job_row_vector').length + 1;
 			// Translators: "Cutting Job #number"
-			$(newJob).find('.job_title').text(gettext("Cutting Job ") + i);
+			$(newJob).find('.job_title').text(gettext("Cut ") + i);
 
 			newJob.find('.used_color').remove();
 			newJob.appendTo($('#additional_jobs'));

--- a/octoprint_mrbeam/templates/conversion_dialog.jinja2
+++ b/octoprint_mrbeam/templates/conversion_dialog.jinja2
@@ -339,14 +339,6 @@
 							</div>
 
                             <div class="control-group">
-                                <div class="cutting-control-and-label" data-toggle="tooltip" data-placement="right"
-                                      title="{{ _('Indicates the number of times the laser will run over the design to cut it. Increase the number of passes if the material does not get cut.') }}">
-                                    <label class="control-label">{{ _('Passes') }}</label>
-                                    <div class="controls"><input data-bind="event: {change: flag_customized_material}" class="param_passes img_intensity_input" type="number" min="1" max="10" value="1" />&nbsp;&times;</div>
-                                </div>
-                            </div>
-
-                            <div class="control-group">
                                 <div class="compressor-control-and-label" data-toggle="tooltip" data-placement="right" data-bind="visible: hasCompressor"
                                      title="<b>{{ _('The power of the air compressor.') }}</b>
                                      {{ _('Keep this value to the maximum for the best performance, unless you want to lower it because your material is very light and it\'s blown away.') }}">
@@ -358,6 +350,14 @@
                                             <span class="compressor_min_max_label">max</span>
                                         </div>
                                     </div>
+                                </div>
+                            </div>
+
+                            <div class="control-group">
+                                <div class="cutting-control-and-label" data-toggle="tooltip" data-placement="right"
+                                      title="{{ _('Indicates the number of times the laser will run over the design to cut it. Increase the number of passes if the material does not get cut.') }}">
+                                    <label class="control-label">{{ _('Passes') }}</label>
+                                    <div class="controls"><input data-bind="event: {change: flag_customized_material}" class="param_passes img_intensity_input" type="number" min="1" max="10" value="1" />&nbsp;&times;</div>
                                 </div>
                             </div>
 

--- a/octoprint_mrbeam/templates/conversion_dialog.jinja2
+++ b/octoprint_mrbeam/templates/conversion_dialog.jinja2
@@ -174,7 +174,7 @@
                                 <ul><li>{{ _('Bright/white pixels use the left (lower) value') }}</li>
                                 <li>{{ _('Dark/black pixels use the right (higher) value.') }}</li>
                                 </ul> {{ _('Equal values do not vary the laser intensity related to the pixel brightness.') }}">
-                                    <label class="control-label">{{ _('Laser intensity range') }}</label>
+                                    <label class="control-label">{{ _('Intensity range') }}</label>
                                     <div class="controls range-control">
                                         <div class="input-append">
                                             <input id="svgtogcode_img_intensity_white" class="img_intensity_input percentage_input"  type="number" min="0" max="100"
@@ -193,7 +193,7 @@
                                      <ul><li>{{ _('Bright/white pixels use the left (higher) value') }}</li>
                                      <li>{{ _('Dark/black pixels use the right (lower) value.') }}</li></ul>
                                      {{ _('Equal values do not vary the laser velocity related to the pixel brightness.') }}">
-                                    <label class="control-label">{{ _('Engraving speed range') }}</label>
+                                    <label class="control-label">{{ _('Speed range') }}</label>
                                     <div class="controls range-control">
                                         <div class="input-append">
                                             <input id="svgtogcode_img_feedrate_white" class="img_intensity_input speed_input" type="number"  min="100" max="3000"
@@ -319,7 +319,7 @@
                                       title="<b>{{ _('Sets the intensity of the laser.') }}</b> {{ _('The more intensity the deeper the effect on the material.') }}<br>
 									     {{ _('Cutting needs higher intensities than engraving.') }}<br>
 									     {{ _('The effect in general is dependent from the material and its color and surface.') }}">
-                                     <label class="control-label">{{ _('Laser Intensity') }}</label>
+                                     <label class="control-label">{{ _('Intensity') }}</label>
                                      <div class="controls"><input class="param_intensity img_intensity_input percentage_input" type="number" min="0" max="100"
                                                                  data-bind="event: {change: flag_customized_material}"
                                                                  onblur="window.mrbeam.colorDragging.checkConversionParameters()"/>&nbsp;%</div>
@@ -331,7 +331,7 @@
                                       title="<b>{{ _('Sets the velocity of the laser head.') }}</b> {{ _('The slower the movement the deeper the effect on the material.') }}<br>
                                         {{ _('Cutting needs slower movement than engraving.') }}<br>
 									    {{ _('The effect in general is dependent from the material and its color and surface.') }}">
-                                     <label class="control-label">{{ _('Laser Speed') }}</label>
+                                     <label class="control-label">{{ _('Speed') }}</label>
                                      <div class="controls"><input class="param_feedrate img_intensity_input speed_input" type="number" min="100" max="3000"
 															 data-bind="event: {change: flag_customized_material}"
 															 onblur="window.mrbeam.colorDragging.checkConversionParameters()"/>&nbsp;{{ _('mm/min') }}</div>

--- a/octoprint_mrbeam/templates/conversion_dialog.jinja2
+++ b/octoprint_mrbeam/templates/conversion_dialog.jinja2
@@ -166,7 +166,7 @@
 					</div>
 					<div class="span9">
 						<div class="clearfix">
-							<h4 class="job_title pull-left">{{ _('Engraving') }}</h4>
+							<h4 class="job_title pull-left">{{ _('Engrave') }}</h4>
 						</div>
 						<form class="job_parameters form-horizontal" data-bind="visible: has_engraving_proposal">
 							<div class="control-group" >
@@ -311,7 +311,7 @@
 					</div>
 					<div class="span9">
 						<div class="clearfix">
-							<h4 class="job_title pull-left">{{ _('Cutting Job ') }}1</h4>
+							<h4 class="job_title pull-left">{{ _('Cut ') }}1</h4>
 						</div>
 						<form class="job_parameters form-horizontal" data-bind="visible: has_cutting_proposal">
 							<div class="control-group">


### PR DESCRIPTION
This is how it looks like now: (I'm not 100% sure about how the arrows look, as they are no longer aligned with the min/max labels from the compressor)
![image](https://user-images.githubusercontent.com/28774305/69652928-b2c82a00-1072-11ea-8e84-599c35f5b6f0.png)
Is the wording for speed/intensity good?