### PR TITLE
Overshoot enabled. Added setting to advanced laser parameters to test overshoot

### DIFF
--- a/octoprint_mrbeam/gcodegenerator/converter.py
+++ b/octoprint_mrbeam/gcodegenerator/converter.py
@@ -263,6 +263,7 @@ class Converter():
 											workingAreaWidth = self.workingAreaWidth,
 											workingAreaHeight = self.workingAreaHeight,
 						                    beam_diameter = rasterParams['beam_diameter'],
+						                    overshoot_distance = rasterParams.get('overshoot', 0),
 											intensity_black = rasterParams['intensity_black'],
 											intensity_white = rasterParams['intensity_white'],
 											intensity_black_user = rasterParams['intensity_black_user'],
@@ -285,7 +286,7 @@ class Converter():
 							ip.imgurl_to_gcode(data, w, h, upperLeft[0], lowerRight[1], file_id)
 						else:
 							self._log.error("Unable to parse img data", data)
-						
+
 						profiler.nest_data(ip.get_profiler())
 
 						processedItemCount += 1
@@ -348,12 +349,12 @@ class Converter():
 						# TODO sort paths
 						# check length (below ??? paths sort, above just go)
 						# while len(paths_by_color[colorKey]) > 0:
-							# get current pos 
+							# get current pos
 							# pick closest starting point to (current_x, current_y)
 							# process...
 							# set current_x, current_y
 							# drop from list
-						
+
 						for path in paths_by_color[colorKey]:
 							curveGCode = ""
 							mbgc = path.get(_add_ns('gc', 'mb'), None)
@@ -372,7 +373,7 @@ class Converter():
 								fh.write("; pass:%i/%s\n" % (p+1, settings['passes']))
 								# TODO tbd DreamCut different for each pass?
 								fh.write(curveGCode)
-							
+
 
 						# TODO check if _after_job should be one(two?) levels less indented
 						# gcode_after_job

--- a/octoprint_mrbeam/gcodegenerator/img2gcode.py
+++ b/octoprint_mrbeam/gcodegenerator/img2gcode.py
@@ -158,10 +158,6 @@ class ImageProcessor():
 		comment += "; eng_compressor = {}\n".format(self.compressor)
 		return comment
 
-	def set_overshoot_parameter(self, overshoot_distance, workingAreaWidth=500):
-		self.overshoot_distance = overshoot_distance
-		self.workingAreaWidth = workingAreaWidth
-
 	def img_prepare(self, img, w_mm, h_mm):
 		"""
 		1. pixel reduction (w,h)
@@ -207,7 +203,7 @@ class ImageProcessor():
 		self.log.info("#####")
 		self.log.info(bbox)
 		self.log.info((0,0,dest_wpx, dest_hpx))
-		
+
 		if(False):
 			self.profiler.start('crop')
 
@@ -284,7 +280,7 @@ class ImageProcessor():
 				self.separation = False
 				self.line_by_line = True
 				self.log.warn("Dithering overwrites engraving mode (workaround for #455)") # TODO fix in frontend. separation does never make sense with dithering
-				
+
 			if(self.debugPreprocessing):
 				img.save("/tmp/img2gcode_6_dithered.png")
 
@@ -448,7 +444,7 @@ class ImageProcessor():
 		# pragmatic O(n^2) sorting
 		out = []
 		# We want the laserhead begins bottom left (ltr reading direction). So put this as starting point.
-		lastPos = (0, self.workingAreaHeight/self.beam) # untransformed px coordinates here: 0,0 is top left. 
+		lastPos = (0, self.workingAreaHeight/self.beam) # untransformed px coordinates here: 0,0 is top left.
 		while(len(imgArray) > 0):
 			dist = float('inf')
 			closest = None
@@ -459,13 +455,13 @@ class ImageProcessor():
 				if(dst < dist):
 					closest = img
 					dist = dst
-			
+
 			out.append(closest)
 			imgArray.remove(closest)
 			lastPos = (closest['x']+closest['i'].size[0], closest['y'])
 
 		return out
-		
+
 	def _dist(self, p0, p1):
 		return math.sqrt((p0[0] - p1[0])**2 + (p0[1] - p1[1])**2)
 

--- a/octoprint_mrbeam/static/js/convert.js
+++ b/octoprint_mrbeam/static/js/convert.js
@@ -80,7 +80,7 @@ $(function(){
 		self.save_custom_material_name = ko.observable("");
 		self.save_custom_material_thickness = ko.observable(1);
 		self.save_custom_material_color = ko.observable("#000000");
-		
+
 
 		self.hasCompressor = ko.observable(false);
 
@@ -646,6 +646,7 @@ $(function(){
 		self.imgFeedrateBlack = ko.observable(250);
 		self.imgDithering = ko.observable(false);
 		self.beamDiameter = ko.observable(0.15);
+		self.overshoot = ko.observable(1.0);
 		self.engravingPiercetime = ko.observable(0);
 		self.engravingCompressor = ko.observable(0);
 
@@ -864,6 +865,7 @@ $(function(){
 				"speed_white" : parseInt(self.imgFeedrateWhite()),
 				"dithering" : self.imgDithering(),
 				"beam_diameter" : parseFloat(self.beamDiameter()),
+				"overshoot" : parseFloat(self.overshoot()),
 				"pierce_time": parseInt(self.engravingPiercetime()),
 				"engraving_mode": $('#svgtogcode_img_engraving_mode > .btn.active').attr('value'),
                 "line_distance": $('#svgtogcode_img_line_dist').val(),

--- a/octoprint_mrbeam/templates/conversion_dialog.jinja2
+++ b/octoprint_mrbeam/templates/conversion_dialog.jinja2
@@ -265,6 +265,13 @@
                                     <div class="controls"><input id="svgtogcode_img_line_dist" class="img_intensity_input decimal_input" type="number" max="1.0" min="0.1" step="0.05" data-bind="value: beamDiameter" />&nbsp;{{ _('mm') }}</div>
                                 </div>
 
+                                <div class="input-control-and-label" data-toggle="tooltip" data-placement="right"
+                                     title="{{ _('BETA! Ignored if pierce time is set.') }}">
+                                    <label class="control-label">{{ _('Overshoot') }}</label>
+                                    <div class="controls">
+                                        <input id="svgtogcode_img_overshoot" class="img_intensity_input decimal_input" type="number" max="10.0" min="0.0" step="0.1" data-bind="value: overshoot" />&nbsp;{{ _('mm') }}</div>
+                                </div>
+
                                 <div class="switch-control-and-label" data-toggle="tooltip" data-placement="right"
                                     title="{{ _('All engravings are processed line by line from bottom to top.') }}
 									        {{ _('The system may cluster objects and process them separately from each other to <b>improve overall job duration by reducing \'empty rides\'</b> where the laser stays off.') }}
@@ -291,6 +298,7 @@
                                     <button type="button" value="basic" id="parameter_assignment_engraving_mode_basic_btn" class="btn btn-default">{{ _('Basic') }}</button>
                                   </div>
                                 </div>
+
                               </div>
 
 								<h5>{{ _('Image Preprocessing') }}</h5>


### PR DESCRIPTION
The overshoot feature was already implemented long time ago by Teja. This is just to make it accessible.

Once we release it publicly (STABLE) we should remove the frontend input field and set the overshoot_distance always to 1 mm.