### PR TITLE
Calibration screen compatibility

### DIFF
--- a/octoprint_mrbeam/__init__.py
+++ b/octoprint_mrbeam/__init__.py
@@ -1536,10 +1536,16 @@ class MrBeamPlugin(octoprint.plugin.SettingsPlugin,
 		# transform dict
 		# todo replace/do better
 		newCorners = {}
-		for qd in data['result']['newCorners']:
-			newCorners[qd] = [data['result']['newCorners'][qd]['x'],data['result']['newCorners'][qd]['y']]
-
 		newMarkers = {}
+		for qd in data['result']['newCorners']:
+			if 'x' in data['result']['newCorners'][qd].keys():
+				# Legacy algo
+				newCorners[qd] = [data['result']['newCorners'][qd]['x'],data['result']['newCorners'][qd]['y']]
+			else:
+				# New algo
+				newCorners[qd] = data['result']['newCorners'][qd]
+
+
 		for qd in data['result']['newMarkers']:
 			newMarkers[qd] = [data['result']['newMarkers'][qd]['x'],data['result']['newMarkers'][qd]['y']]
 
@@ -1549,6 +1555,7 @@ class MrBeamPlugin(octoprint.plugin.SettingsPlugin,
 		pic_settings['cornersFromImage'] = newCorners
 		pic_settings['calibMarkers'] = newMarkers
 		pic_settings['calibration_updated'] = True
+		pic_settings['hostname_KEY'] = self._hostname
 
 		self._logger.debug('picSettings new to save: {}'.format(pic_settings))
 		self._save_profile(pic_settings_path,pic_settings)

--- a/octoprint_mrbeam/__init__.py
+++ b/octoprint_mrbeam/__init__.py
@@ -1537,17 +1537,18 @@ class MrBeamPlugin(octoprint.plugin.SettingsPlugin,
 		# todo replace/do better
 		newCorners = {}
 		newMarkers = {}
-		for qd in data['result']['newCorners']:
-			if 'x' in data['result']['newCorners'][qd].keys():
-				# Legacy algo
-				newCorners[qd] = [data['result']['newCorners'][qd]['x'],data['result']['newCorners'][qd]['y']]
-			else:
-				# New algo
-				newCorners[qd] = data['result']['newCorners'][qd]
 
+
+		for qd in data['result']['newCorners']:
+			newCorners[qd] = [data['result']['newCorners'][qd]['x'],data['result']['newCorners'][qd]['y']]
 
 		for qd in data['result']['newMarkers']:
-			newMarkers[qd] = [data['result']['newMarkers'][qd]['x'],data['result']['newMarkers'][qd]['y']]
+			if type(data['result']['newMarkers'][qd]) is dict:
+				# Legacy algo
+				newMarkers[qd] = [data['result']['newMarkers'][qd]['x'],data['result']['newMarkers'][qd]['y']]
+			else:
+				# New algo
+				newMarkers[qd] = data['result']['newMarkers'][qd]
 
 		pic_settings_path = self._settings.get(["cam", "correctionSettingsFile"])
 		pic_settings = self._load_profile(pic_settings_path)

--- a/octoprint_mrbeam/camera/undistort.py
+++ b/octoprint_mrbeam/camera/undistort.py
@@ -60,6 +60,7 @@ def prepareImage(input_image,  #: Union[str, np.ndarray],
                  size=RESOLUTIONS['1000x780'],
                  quality=90,
                  debug_out=False,
+                 undistorted=False,
                  blur=7,
                  custom_pic_settings=None,
                  stopEvent=None,
@@ -129,7 +130,7 @@ def prepareImage(input_image,  #: Union[str, np.ndarray],
     # undistort image with cam_params
     img = _undistortImage(img, cam_dist, cam_matrix)
 
-    if debug_out:
+    if debug_out or undistorted:
         save_debug_img(img, path_to_output_image, "undistorted")
 
     if stopEvent and stopEvent.isSet(): return None, None, None, STOP_EVENT_ERR
@@ -513,8 +514,8 @@ def save_debug_img(img, normal_img_path, folderName):
     cv2.imwrite(dbg_path, img)
 
 def _mkdir(folder):
-    if not exists(dirname(folder)):
-        os.mkdir(dirname(folder))
+    if not exists(folder):
+        os.makedirs(folder)
 
 def _getCamParams(path_to_params_file):
     """

--- a/octoprint_mrbeam/iobeam/lid_handler.py
+++ b/octoprint_mrbeam/iobeam/lid_handler.py
@@ -409,6 +409,7 @@ class PhotoCreator(object):
                                                                          quality=quality)
                 if not self.active(): break
 
+                self._logger.debug("correct result 2 %s", correction_result2)
                 if not success_2:
                     errorID = correction_result2['error'].split(':')[0]
                     errorString = correction_result2['error'].split(':')[1]
@@ -461,7 +462,8 @@ class PhotoCreator(object):
                                                               last_markers=last_markers,
                                                               size=out_pic_size,
                                                               quality=quality,
-                                                              debug_out=self.debug,  # self.save_debug_images,
+                                                              debug_out=self.save_debug_images,  # self.save_debug_images,
+                                                              undistorted=True,
                                                               stopEvent=self.stopEvent,
                                                               threads=4)
         if not self.active(): return False, None, None, None, None
@@ -473,6 +475,7 @@ class PhotoCreator(object):
                              'corners_calculated':    None if workspaceCorners is None else list(workspaceCorners),
                              # {k: v.astype(int) for k, v in workspaceCorners.items()},
                              'successful_correction': success_1,
+                             'undistorted_saved':     True,
                              'error': err}
         return success_1, correction_result, markers, missed, err
 

--- a/octoprint_mrbeam/iobeam/lid_handler.py
+++ b/octoprint_mrbeam/iobeam/lid_handler.py
@@ -474,6 +474,7 @@ class PhotoCreator(object):
                              'markers_recognised':    4 - len(missed),
                              'corners_calculated':    None if workspaceCorners is None else list(workspaceCorners),
                              # {k: v.astype(int) for k, v in workspaceCorners.items()},
+                             'markers_pos':           {qd: pos.tolist() for qd, pos in markers.items()},
                              'successful_correction': success_1,
                              'undistorted_saved':     True,
                              'error': err}

--- a/octoprint_mrbeam/static/js/settings/camera_calibration.js
+++ b/octoprint_mrbeam/static/js/settings/camera_calibration.js
@@ -128,7 +128,7 @@ $(function () {
 
 		self.startCalibration = function () {
 			self.analytics.send_fontend_event('calibration_start', {});
-			self.currentResults({});
+			// self.currentResults({});
 			self.calibrationActive(true);
 			self.picType("lens_correction");
 			self.nextMarker();
@@ -268,22 +268,23 @@ $(function () {
 				console.log('New Image [NW,NE,SW,SE]:', data['beam_cam_new_image']);
 				// update markers
 				var markers = data['beam_cam_new_image']['markers_found'];
-				if(!self.calibrationActive()){
-					if(markers instanceof Array) {
-						// New algo
-						self.foundNW(markers.includes('NW'));
-						self.foundNE(markers.includes('NE'));
-						self.foundSW(markers.includes('SW'));
-						self.foundSE(markers.includes('SE'));
-					} else {
-						// Legacy algo
-						self.foundNW(markers['NW'] && markers['NW'].recognized);
-						self.foundNE(markers['NE'] && markers['NE'].recognized);
-						self.foundSW(markers['SW'] && markers['SW'].recognized);
-						self.foundSE(markers['SE'] && markers['SE'].recognized);
-					}
-					self.foundNW.notifySubscribers(); // somehow doesn't trigger automatically
+				// Not taking care of an active calibration or not allows for an immediate calibration based on previous marker detection
+				// if(!self.calibrationActive()){
+				if(markers instanceof Array) {
+					// New algo
+					self.foundNW(markers.includes('NW'));
+					self.foundNE(markers.includes('NE'));
+					self.foundSW(markers.includes('SW'));
+					self.foundSE(markers.includes('SE'));
+				} else {
+					// Legacy algo
+					self.foundNW(markers['NW'] && markers['NW'].recognized);
+					self.foundNE(markers['NE'] && markers['NE'].recognized);
+					self.foundSW(markers['SW'] && markers['SW'].recognized);
+					self.foundSE(markers['SE'] && markers['SE'].recognized);
 				}
+				self.foundNW.notifySubscribers(); // somehow doesn't trigger automatically
+				// }
 				// update image
 				if (data['beam_cam_new_image']['undistorted_saved']) {
 					self.calImgUrl(self.camImgPath + '?' + new Date().getTime());
@@ -299,7 +300,13 @@ $(function () {
 					// check if all markers are found and image is good for calibration
 					if (self.cal_img_ready()) {
 						console.log("Remembering markers for Calibration", markers);
-						self.currentMarkersFound = markers;
+						if (markers instanceof array){
+							// New alog
+							self.currentMarkersFound = data['beam_cam_new_image']['markers_pos']
+						} else {
+							// Legacy algo
+							self.currentMarkersFound = markers;
+						}
 					} else {
 						console.log("Not all Markers found, fetching new Picture.");
 						self.loadUndistortedPicture();

--- a/octoprint_mrbeam/static/js/settings/camera_calibration.js
+++ b/octoprint_mrbeam/static/js/settings/camera_calibration.js
@@ -60,7 +60,7 @@ $(function () {
 		self.calibrationActive = ko.observable(false);
 		self.currentResults = ko.observable({});
 		self.calibrationComplete = ko.computed(function(){
-			console.log("current results : ", self.currentResults());
+			// console.log("current results : ", self.currentResults());
 			var markers = ['NW', 'NE', 'SW', 'SE'];
 			for (var i = 0; i < markers.length; i++) {
 				var k = markers[i];
@@ -265,7 +265,7 @@ $(function () {
 			}
 
 			if ('beam_cam_new_image' in data) {
-				console.log('New Image [NW,NE,SW,SE]:', data['beam_cam_new_image']);
+				// console.log('New Image [NW,NE,SW,SE]:', data['beam_cam_new_image']);
 				// update markers
 				var markers = data['beam_cam_new_image']['markers_found'];
 				// Not taking care of an active calibration or not allows for an immediate calibration based on previous marker detection
@@ -299,17 +299,21 @@ $(function () {
 
 					// check if all markers are found and image is good for calibration
 					if (self.cal_img_ready()) {
-						console.log("Remembering markers for Calibration", markers);
-						if (markers instanceof array){
+						// console.log("Remembering markers for Calibration", markers);
+						if (markers instanceof Array){
 							// New alog
-							self.currentMarkersFound = data['beam_cam_new_image']['markers_pos']
+							self.currentMarkersFound = data['beam_cam_new_image']['markers_pos'];
+							//	i, j -> x, y conversion
+							['NW', 'NE', 'SE', 'SW'].forEach(function(m) {self.currentMarkersFound[m] = self.currentMarkersFound[m].reverse();} );
 						} else {
 							// Legacy algo
 							self.currentMarkersFound = markers;
 						}
-					} else {
-						console.log("Not all Markers found, fetching new Picture.");
-						self.loadUndistortedPicture();
+					}
+					else if(self.calibrationActive()){
+						console.log("Not all Markers found, are the pink circles obstructed?");
+						// As long as all the corners were not found, the camera will continue to take pictures
+						// self.loadUndistortedPicture();
 					}
 				}
 			}


### PR DESCRIPTION
The calibration screen can now use the new algo for creating the pic_settings JSON.

NOTE : Both the new and the legacy algo use the same picture settngs. Given that their avg measurement is different, this means that the algo that is used to calibrate will give better results.

No extra effort was done in that regard given that:
- The new algo has priority when it comes to display a refreshed image
- We don't want to sit on a "One camera 2 systems policy" forever

NOTE2: It seems we get the "Requesting picture" message without visiting the calibration screen. Still investigating.

Bonus fix : The hostname in pic_settings.yaml is changed to reflect the device that last wrote into it 