### PR TITLE
Remove search area offsets 

### DIFF
--- a/octoprint_mrbeam/camera/__init__.py
+++ b/octoprint_mrbeam/camera/__init__.py
@@ -35,7 +35,7 @@ QD_KEYS = [NW,NE,SW,SE]
 # Size of the corner search area
 RATIO_W, RATIO_H = Fraction(1, 8), Fraction(1, 4)
 # Padding distance from the edges of the image (The markers are never pressed against the border)
-OFFSET_W, OFFSET_H = Fraction(0, 36), Fraction(1, 20)
+OFFSET_W, OFFSET_H = Fraction(0, 36), Fraction(0, 20)
 
 LEGACY_STILL_RES = RESOLUTIONS['2048x1536'] # from octoprint_mrbeam __init___ : get_settings_defaults
 DEFAULT_STILL_RES = RESOLUTIONS['2592x1944']  # Be careful : Resolutions accepted as increments of 32 horizontally and 16 vertically


### PR DESCRIPTION
Some camera not centered on workspace, so some markers are cropped off. The camera on those Mr Beams are probably not capturing the whole workspace.