### PR TITLE
Increase tolerance for motion detection.

### DIFF
--- a/octoprint_mrbeam/camera/__init__.py
+++ b/octoprint_mrbeam/camera/__init__.py
@@ -42,7 +42,7 @@ DEFAULT_STILL_RES = RESOLUTIONS['2592x1944']  # Be careful : Resolutions accepte
 
 # threshold; 2 consecutive pictures need to have a minimum difference
 # before being undistorted and served
-DIFF_TOLERANCE = 30
+DIFF_TOLERANCE = 50
 
 
 class MrbPicWorker(object):


### PR DESCRIPTION
A lot of customers complain about excessive amounts of LQ pictures. Presumably, something might be moving on the workspace, probably just shadows.
This fix should make it more tolerable.