### PR TITLE
Ignore calibration file

### DIFF
--- a/octoprint_mrbeam/camera/__init__.py
+++ b/octoprint_mrbeam/camera/__init__.py
@@ -42,7 +42,7 @@ DEFAULT_STILL_RES = RESOLUTIONS['2592x1944']  # Be careful : Resolutions accepte
 
 # threshold; 2 consecutive pictures need to have a minimum difference
 # before being undistorted and served
-DIFF_TOLERANCE = 30
+DIFF_TOLERANCE = 50
 
 
 class MrbPicWorker(object):


### PR DESCRIPTION
This suppresses warnings about the missing calibration file.

Only the new marker detection algo will be used when the file is missing.

This allows us to test how much the calibration of the camera impacts the final result and precision of the camera.