### PR TITLE
MMAL Error : Attempt to fix & Notify Front End it case it doesn't

### DIFF
--- a/octoprint_mrbeam/camera/exc.py
+++ b/octoprint_mrbeam/camera/exc.py
@@ -8,15 +8,14 @@ except ImportError, OSError:
 CameraException = _Exc
 CameraConnectionException = _ConnErr
 
-(CAM_CONN,
- CAM_CONNRECOVER,
- ) = range(2)
+CAM_CONN = "err_cam_conn"
+CAM_CONNRECOVER = "cam_conn_recover"
 
 def msg(status):
-	return {CAM_CONN:        "Camera connection error",
+	return {CAM_CONN: "Camera connection error",
 	        CAM_CONNRECOVER: "Managed to recover from the previous camera error",
-            }.get(status, "Unknown status error")
+	        }.get(status, "Unknown status error")
 
-def formatForAnalytics(status, count=1):
-	return {status: {'msg': msg(status),
-	                 'count': count}}
+def msgForAnalytics(status):
+	return {'message': msg(status),
+	        'id': status}

--- a/octoprint_mrbeam/camera/exc.py
+++ b/octoprint_mrbeam/camera/exc.py
@@ -1,15 +1,9 @@
 try:
-	import picamera
-	Err = picamera.exc.PiCameraError
-	MMALErr = picamera.exc.PiCameraMMALError
+	import picamera.exc.PiCameraError as _Exc
+	import picamera.exc.PiCameraMMALError as _ConnErr
 except ImportError, OSError:
-	Err = Exception
-	MMALErr = Exception
+	_Exc = Exception
+	_ConnErr = Exception
 
-class CameraException(Err):
-	pass
-
-class CameraConnectionException(MMALErr, Err):
-	def __init__(self, status, prefix=""):
-		MMALErr.__init__(self, status)
-	pass
+CameraException = _Exc
+CameraConnectionException = _ConnErr

--- a/octoprint_mrbeam/camera/exc.py
+++ b/octoprint_mrbeam/camera/exc.py
@@ -7,3 +7,16 @@ except ImportError, OSError:
 
 CameraException = _Exc
 CameraConnectionException = _ConnErr
+
+(CAM_CONN,
+ CAM_CONNRECOVER,
+ ) = range(2)
+
+def msg(status):
+	return {CAM_CONN:        "Camera connection error",
+	        CAM_CONNRECOVER: "Managed to recover from the previous camera error",
+            }.get(status, "Unknown status error")
+
+def formatForAnalytics(status, count=1):
+	return {status: {'msg': msg(status),
+	                 'count': count}}

--- a/octoprint_mrbeam/camera/exc.py
+++ b/octoprint_mrbeam/camera/exc.py
@@ -1,0 +1,15 @@
+try:
+	import picamera
+	Err = picamera.exc.PiCameraError
+	MMALErr = picamera.exc.PiCameraMMALError
+except ImportError, OSError:
+	Err = Exception
+	MMALErr = Exception
+
+class CameraException(Err):
+	pass
+
+class CameraConnectionException(MMALErr, Err):
+	def __init__(self, status, prefix=""):
+		MMALErr.__init__(self, status)
+	pass

--- a/octoprint_mrbeam/camera/mrbcamera.py
+++ b/octoprint_mrbeam/camera/mrbcamera.py
@@ -52,7 +52,8 @@ class LoopThread(threading.Thread):
 		try:
 			threading.Thread.run(self)
 		except Exception as e:
-			self._logger.warning("mrbeam.loopthread : %s, %s", e.__class__.__name__, e)
+			self._logger.exception("mrbeam.loopthread : %s, %s", e.__class__.__name__, e)
+			raise
 
 	def _loop(self):
 		self.running.set()

--- a/octoprint_mrbeam/iobeam/lid_handler.py
+++ b/octoprint_mrbeam/iobeam/lid_handler.py
@@ -97,11 +97,9 @@ class LidHandler(object):
 		if event == IoBeamEvents.INTERLOCK_OPEN:
 			self._logger.debug("onEvent() INTERLOCK_OPEN")
 			self._interlock_closed = False
-			self._startStopCamera(event)
 		if event == IoBeamEvents.INTERLOCK_CLOSED:
 			self._logger.debug("onEvent() INTERLOCK_CLOSED")
 			self._interlock_closed = True
-			self._startStopCamera(event)
 		elif event == IoBeamEvents.LID_CLOSED:
 			self._logger.debug("onEvent() LID_CLOSED")
 			self._lid_closed = True

--- a/octoprint_mrbeam/iobeam/lid_handler.py
+++ b/octoprint_mrbeam/iobeam/lid_handler.py
@@ -19,6 +19,7 @@ import octoprint_mrbeam.camera
 from octoprint_mrbeam.camera.mrbcamera import MrbCamera
 from octoprint_mrbeam.camera import gaussBlurDiff, QD_KEYS, PICAMERA_AVAILABLE
 from octoprint_mrbeam.util import json_serialisor, logme
+import octoprint_mrbeam.camera.exc as exc
 if PICAMERA_AVAILABLE:
 	from octoprint_mrbeam.camera.undistort import prepareImage, MAX_OBJ_HEIGHT, \
 		CAMERA_HEIGHT, _getCamParams, _getPicSettings, DIST_KEY, MTX_KEY
@@ -324,7 +325,12 @@ class PhotoCreator(object):
 			# bestShutterSpeeds = cam.apply_best_shutter_speed()  # Usually only 1 value, but there could be more
 			# TODO cam.anti_rolling_shutter_banding()
 			if not self.active(): return
-			cam.start()  # starts capture to the cam.worker
+			try:
+				cam.start()  # starts capture to the cam.worker
+			except exc.CameraConnectionException as e:
+				cam.stop()
+				self._logger.error(" %s, %s", e.__class__.__name__, e)
+				return
 			# --- Decide on the picture quality to give to the user and whether the pic is different ---
 			prev = None # previous image
 			nb_consecutive_similar_pics = 0

--- a/octoprint_mrbeam/iobeam/lid_handler.py
+++ b/octoprint_mrbeam/iobeam/lid_handler.py
@@ -287,6 +287,9 @@ class PhotoCreator(object):
                            resolution=octoprint_mrbeam.camera.LEGACY_STILL_RES,  # TODO camera.DEFAULT_STILL_RES,
                            stopEvent=self.stopEvent,) as cam:
 				self.serve_pictures(cam)
+			if recurse_nb > 0:
+				self._analytics_handler.add_camera_session_details({'errors': exc.formatForAnalytics(exc.CAM_CONNRECOVER)})
+				pass
 		except exc.CameraConnectionException as e:
 			self._logger.exception(" %s, %s", e.__class__.__name__, e)
 			if recurse_nb < MAX_PIC_THREAD_RETRIES:
@@ -304,6 +307,8 @@ class PhotoCreator(object):
 					self._plugin.user_notification_system.get_notification(
 						notification_id='err_cam_conn_err',
 						replay=True))
+				self._analytics_handler.add_camera_session_details({'errors': exc.formatForAnalytics(exc.CAM_CONN,
+				                                                                                     count=MAX_PIC_THREAD_RETRIES)})
 			return
 		except Exception as e:
 			if e.__class__.__name__.startswith('PiCamera'):

--- a/octoprint_mrbeam/iobeam/lid_handler.py
+++ b/octoprint_mrbeam/iobeam/lid_handler.py
@@ -68,7 +68,7 @@ class LidHandler(object):
 			self._photo_creator = PhotoCreator(self._plugin,
                                                self._plugin_manager,
                                                imagePath,
-                                               debug=True)
+                                               debug=False)
 		else:
 			self._photo_creator = None
 		self._analytics_handler = self._plugin.analytics_handler

--- a/octoprint_mrbeam/static/js/user_notification_viewmodel.js
+++ b/octoprint_mrbeam/static/js/user_notification_viewmodel.js
@@ -46,7 +46,10 @@ $(function () {
                 text: gettext("The camera has had a small issue, please restart your Mr Beam if you need to use the camera to continue with your work."),
                 type: 'error',
                 hide: false,
-            }
+                knowledgebase: {
+                    url: 'https://support.mr-beam.org/en/support/solutions/articles/43000570474-error-camera-error',
+                }
+            },
         };
 
 

--- a/octoprint_mrbeam/static/js/user_notification_viewmodel.js
+++ b/octoprint_mrbeam/static/js/user_notification_viewmodel.js
@@ -47,7 +47,7 @@ $(function () {
                 type: 'error',
                 hide: false,
                 knowledgebase: {
-                    url: 'https://support.mr-beam.org/en/support/solutions/articles/43000570474-error-camera-error',
+                    url: 'https://support.mr-beam.org/support/solutions/articles/43000570474-error-camera-error',
                 }
             },
         };

--- a/octoprint_mrbeam/static/js/user_notification_viewmodel.js
+++ b/octoprint_mrbeam/static/js/user_notification_viewmodel.js
@@ -34,8 +34,14 @@ $(function () {
                 knowledgebase: {
                     url: 'https://mr-beam.freshdesk.com/support/solutions/articles/43000557281-error-hardware-malfunction',
                 }
+            },
+            warn_cam_conn_err: {
+                title: gettext("Camera busy"),
+                text: gettext("The camera has had a small issue, it will take a few seconds to restart"),
+                type: 'info',
+                hide: true,
             }
-        }
+        };
 
 
         self.onDataUpdaterPluginMessage = function (plugin, data) {
@@ -47,15 +53,15 @@ $(function () {
                 let nu_notifications = data['user_notification_system']['notifications'] || [];
 
                 for (let i = 0; i < nu_notifications.length; i++) {
-                    let pn_obj = self._getPnObj(nu_notifications[i])
+                    let pn_obj = self._getPnObj(nu_notifications[i]);
 
                     // find notification in screen
-                    let existing_notification = null
+                    let existing_notification = null;
                     for (let n = 0; n < PNotify.notices.length; n++) {
                         if (PNotify.notices[n].state != 'closed' &&
                             PNotify.notices[n].options &&
                             PNotify.notices[n].options.id == nu_notifications[i].notification_id) {
-                            existing_notification = PNotify.notices[n]
+                            existing_notification = PNotify.notices[n];
                             break;
                         }
                     }
@@ -76,7 +82,7 @@ $(function () {
                     type: notification_conf.type || 'info',
                     hide: notification_conf.hide === undefined ? true : notification_conf.hide,
                     delay: notification_conf.delay || 10 * 1000,
-                }
+                };
             if (notification_conf.notification_id in self._notification_templates) {
                 pn_obj = {...pn_obj, ...self._notification_templates[notification_conf.notification_id]}
             }
@@ -89,20 +95,20 @@ $(function () {
             }
 
             return pn_obj
-        }
+        };
 
         self._getKnowledgeBaseLink = function (kb_konf) {
-            let specific_url = 'url' in kb_konf
-            let kb_url = kb_konf.url || "https://mr-beam.org/support"
+            let specific_url = 'url' in kb_konf;
+            let kb_url = kb_konf.url || "https://mr-beam.org/support";
             let default_params = {
                 utm_medium: 'beamos',
                 utm_source: 'beamos',
                 utm_campaign: "notification",
                 version: BEAMOS_VERSION,
                 env: MRBEAM_ENV_LOCAL,
-            }
+            };
             // this merges two objects. If both objects have a property with the same name, then the second object property overwrites the first.
-            let kb_params = {...default_params, ...kb_konf.params}
+            let kb_params = {...default_params, ...kb_konf.params};
             kb_url = kb_url + '?' + $.param(kb_params);
             if (specific_url) {
                 return "<br /><br />" +
@@ -120,7 +126,7 @@ $(function () {
                             'closing_tag': '</strong></a>',
                         })
             }
-        }
+        };
 
         self._getErrorString = function (err) {
             if (err) {
@@ -131,7 +137,7 @@ $(function () {
 
         }
 
-    };
+    }
 
     // view model class, parameters for constructor, container to bind to
     OCTOPRINT_VIEWMODELS.push([

--- a/octoprint_mrbeam/static/js/user_notification_viewmodel.js
+++ b/octoprint_mrbeam/static/js/user_notification_viewmodel.js
@@ -42,7 +42,7 @@ $(function () {
                 hide: true,
             },
             err_cam_conn_err: {
-                title: gettext("Camera connection Error"),
+                title: gettext("Camera Error"),
                 text: gettext("The camera has had a small issue, please restart your Mr Beam if you need to use the camera to continue with your work."),
                 type: 'error',
                 hide: false,

--- a/octoprint_mrbeam/static/js/user_notification_viewmodel.js
+++ b/octoprint_mrbeam/static/js/user_notification_viewmodel.js
@@ -37,9 +37,15 @@ $(function () {
             },
             warn_cam_conn_err: {
                 title: gettext("Camera busy"),
-                text: gettext("The camera has had a small issue, it will take a few seconds to restart"),
+                text: gettext("The camera was stopped recently, it will take a few seconds to restart."),
                 type: 'info',
                 hide: true,
+            },
+            err_cam_conn_err: {
+                title: gettext("Camera connection Error"),
+                text: gettext("The camera has had a small issue, please restart your Mr Beam if you need to use the camera to continue with your work."),
+                type: 'error',
+                hide: false,
             }
         };
 


### PR DESCRIPTION
Attempt to completely avoid starting a PhotoCreator thread while an other one is using the camera (current belief behind the cause of the MMAL Error

This message shows in case the error happens
![Screenshot from 2020-04-16 01-48-11](https://user-images.githubusercontent.com/24782867/79400002-308ac480-7f85-11ea-9552-59c2d272bb71.png)

These are the threading.Event elements that makes it possible :

- `active` flag : whether the camera is in use
- `stopEvent` : whether we are trying to exit the current PhotoCreator thread