### PR TITLE
Add Support for Firefox mouse scroll to zoom.

### DIFF
--- a/octoprint_mrbeam/static/js/working_area.js
+++ b/octoprint_mrbeam/static/js/working_area.js
@@ -2731,11 +2731,11 @@ $(function(){
 		};
 
 		self.wheel_zoom_monitor = function(target, ev){
-			var wheel = ev.originalEvent.wheelDelta;
+			var wheel = ev.originalEvent.deltaY;
 			var targetBBox = ev.currentTarget.getBoundingClientRect();
-			var xPerc = (ev.clientX - targetBBox.left) / targetBBox.width;
-			var yPerc = (ev.clientY - targetBBox.top) / targetBBox.height;
-			var deltaZoom = Math.sign(-wheel)/100;
+			var xPerc = (ev.originalEvent.clientX - targetBBox.left) / targetBBox.width;
+			var yPerc = (ev.originalEvent.clientY - targetBBox.top) / targetBBox.height;
+			var deltaZoom = Math.sign(wheel)/100;
 			self.set_zoom_factor(deltaZoom, xPerc, yPerc);
 		};
 

--- a/octoprint_mrbeam/templates/tab_workingarea.jinja2
+++ b/octoprint_mrbeam/templates/tab_workingarea.jinja2
@@ -546,7 +546,7 @@
 											viewBox: zoomViewBox(),
 											visibility: 'visible'
 										},
-										event: { mousewheel: wheel_zoom_wa, mousemove: mouse_drag_wa }
+										event: { wheel: wheel_zoom_wa, mousemove: mouse_drag_wa }
 									 "
 									 xmlns:mb="http://www.mr-beam.org/mbns">
 								<defs>


### PR DESCRIPTION
Changes the wheel event .
According to [Mozilla](https://developer.mozilla.org/en-US/docs/Web/API/Element/wheel_event) it is compatible everywhere.

Obviously one would need to disable the use of shift key for iOS, but if it's the case then we could change the status of #98