### PR TITLE
B 836 y shifted vectors

### DIFF
--- a/octoprint_mrbeam/__init__.py
+++ b/octoprint_mrbeam/__init__.py
@@ -443,6 +443,7 @@ class MrBeamPlugin(octoprint.plugin.SettingsPlugin,
 		assets = dict(
 
 			js=["js/helpers/quick_shape_helper.js",
+			    "js/helpers/debug_rendering_helper.js",
 			    "js/helpers/working_area_helper.js",
 			    "js/lib/jquery.tinycolorpicker.js",
 			    "js/lasercutterprofiles.js",

--- a/octoprint_mrbeam/static/js/helpers/debug_rendering_helper.js
+++ b/octoprint_mrbeam/static/js/helpers/debug_rendering_helper.js
@@ -1,0 +1,58 @@
+/*
+ * helper for easy render debugging.
+ *
+ * Author: Teja
+ * License: AGPLv3
+ */
+
+function debugBase64(base64URL, target="", data=null) {
+	var dbg_link = "<a target='_blank' href='"+base64URL+"' onmouseover=' show_in_popup(\""+base64URL+"\"); '>Hover | Right click -> Open in new tab</a>"; // debug message, no need to translate
+	if(data){
+		dbg_link += "<br/>" + JSON.stringify(data);
+	}
+		new PNotify({
+			title: "render debug output " + target,
+			text: dbg_link,
+			type: "warn",
+			hide: false
+		});
+}
+
+function show_in_popup(dataurl) {
+	$('#debug_rendering_div').remove();
+	$('body').append("<div id='debug_rendering_div' style='position:fixed; top:0; left:0; border:1px solid red; background:center no-repeat; background-size: contain; background-color:aqua; width:50vw; height:50vh; z-index:999999; background-image:url(\""+dataurl+"\")' onclick=' this.remove(); '></div>")
+}
+
+(function(console){
+	/**
+	 * Convenient storing large data objects (json, dataUri, base64 encoded images, ...) from the console.
+	 * 
+	 * @param {object} data to save (means download)
+	 * @param {string} filename used for download
+	 * @returns {undefined}
+	 */
+	console.save = function(data, filename){
+
+		if(!data) {
+			console.error('Console.save: No data')
+			return;
+		}
+
+		if(!filename) filename = 'console.json'
+
+		if(typeof data === "object"){
+			data = JSON.stringify(data, undefined, 4)
+		}
+
+		var blob = new Blob([data], {type: 'text/json'}),
+			e    = document.createEvent('MouseEvents'),
+			a    = document.createElement('a')
+
+		a.download = filename
+		a.href = window.URL.createObjectURL(blob)
+		a.dataset.downloadurl =  ['text/json', a.download, a.href].join(':')
+		e.initMouseEvent('click', true, false, window, 0, 0, 0, 0, 0, false, false, false, false, 0, null)
+		a.dispatchEvent(e)
+	}
+})(console)
+// End Render debugging utilities

--- a/octoprint_mrbeam/static/js/path_magic.js
+++ b/octoprint_mrbeam/static/js/path_magic.js
@@ -694,8 +694,8 @@ var mrbeam = mrbeam || {};
 
   module.gcode = function (paths, id, mb_meta) {
     var commands = [];
-	let first_point = null;
-	let last_point = null;
+	let first_point = {};
+	let last_point = {};
 
     mb_meta = mb_meta || {};
     var meta_str = "";
@@ -732,6 +732,7 @@ var mrbeam = mrbeam || {};
 
   module.clip = function (paths, clip, tolerance) {
     ClipperLib.use_lines = true;
+    const pathCountBeforeClip = paths.length;  
 
     var subj = toIntPaths(paths, tolerance);
     var clip = toIntPaths(clip, tolerance);
@@ -772,6 +773,10 @@ var mrbeam = mrbeam || {};
       clipped.push(path);
 
       polynode = polynode.GetNext();
+    }
+    const pathCountAfterClip = clipped.length;
+    if(pathCountAfterClip < pathCountBeforeClip){
+      console.info("clipped path: " + pathCountBeforeClip + " nodes => "+ pathCountAfterClip);
     }
 
     return clipped.reverse();

--- a/octoprint_mrbeam/static/js/render_fills.js
+++ b/octoprint_mrbeam/static/js/render_fills.js
@@ -132,10 +132,19 @@ Snap.plugin(function (Snap, Element, Paper, global) {
 		}
 
         // Quick fix: in some browsers the bbox is too tight, so we just add an extra 10% to all the sides, making the height and width 20% larger in total
-        bbox.x = bbox.x - bbox.width * 0.4;
-        bbox.y = bbox.y - bbox.height * 0.4;
-        bbox.w = bbox.w * 1.8;
-        bbox.h = bbox.h * 1.8;
+        const enlargement_x = 0.4; // percentage of the width added to each side
+		const enlargement_y = 0.4; // percentage of the height added to each side
+		const x1 = Math.max(0, bbox.x - bbox.width * enlargement_x);
+		const x2 = Math.min(wMM, bbox.x2 + bbox.width * enlargement_x);
+		const w = x2 - x1;
+		const y1 = Math.max(0, bbox.y - bbox.height * enlargement_y);
+		const y2 = Math.min(wMM, bbox.y2 + bbox.height * enlargement_y);
+		const h = y2 - y1;
+		bbox.x = x1;
+        bbox.y = y1;
+        bbox.w = w;
+        bbox.h = h;
+		
 
 		console.info("enlarged renderBBox (in mm): " + bbox.w +'*'+bbox.h + " @ " + bbox.x + ',' + bbox.y);
 

--- a/octoprint_mrbeam/static/js/render_fills.js
+++ b/octoprint_mrbeam/static/js/render_fills.js
@@ -150,6 +150,10 @@ Snap.plugin(function (Snap, Element, Paper, global) {
 		renderCanvas.id = "renderCanvas";
 		renderCanvas.width = bbox.w * pxPerMM;
 		renderCanvas.height = bbox.h * pxPerMM;
+		if(MRBEAM_DEBUG_RENDERING){
+			renderCanvas.style="position: fixed; bottom: 0; left: 0; width: 95vw; border: 1px solid red;";
+			renderCanvas.addEventListener('click', function(){ this.remove(); });
+		}
 		document.getElementsByTagName('body')[0].appendChild(renderCanvas);
 		var renderCanvasContext = renderCanvas.getContext('2d');
 		renderCanvasContext.fillStyle = 'white'; // avoids one backend rendering step (has to be disabled in the backend)
@@ -176,7 +180,9 @@ Snap.plugin(function (Snap, Element, Paper, global) {
 			if(typeof callback === 'function'){
 				callback(fillBitmap, bbox.x, bbox.y, bbox.w, bbox.h);
 			}
-			renderCanvas.remove();
+			if(!MRBEAM_DEBUG_RENDERING){
+				renderCanvas.remove();
+			}
 		};
 
 		// catch browsers without native svg support

--- a/octoprint_mrbeam/static/js/working_area.js
+++ b/octoprint_mrbeam/static/js/working_area.js
@@ -1,59 +1,60 @@
 /* global snap, ko, $, Snap, API_BASEURL, _, CONFIG_WEBCAM_STREAM, ADDITIONAL_VIEWMODELS, mina, BEAMOS_DISPLAY_VERSION, WorkingAreaHelper */
 
 MRBEAM_PX2MM_FACTOR_WITH_ZOOM = 1; // global available in this viewmodel and in snap plugins at the same time.
+
+// Render debugging utilities
 MRBEAM_DEBUG_RENDERING = true;
-if(MRBEAM_DEBUG_RENDERING){
-	function debugBase64(base64URL, target="", data=null) {
-		var dbg_link = "<a target='_blank' href='"+base64URL+"' onmouseover=' show_in_popup(\""+base64URL+"\"); '>Hover | Right click -> Open in new tab</a>"; // debug message, no need to translate
-		if(data){
-			dbg_link += "<br/>" + JSON.stringify(data);
-		}
-			new PNotify({
-				title: "render debug output " + target,
-				text: dbg_link,
-				type: "warn",
-				hide: false
-			});
+function debugBase64(base64URL, target="", data=null) {
+	var dbg_link = "<a target='_blank' href='"+base64URL+"' onmouseover=' show_in_popup(\""+base64URL+"\"); '>Hover | Right click -> Open in new tab</a>"; // debug message, no need to translate
+	if(data){
+		dbg_link += "<br/>" + JSON.stringify(data);
 	}
-	
-	function show_in_popup(dataurl) {
-		$('#debug_rendering_div').remove();
-		$('body').append("<div id='debug_rendering_div' style='position:fixed; top:0; left:0; border:1px solid red; background:center no-repeat; background-size: contain; background-color:aqua; width:50vw; height:50vh; z-index:999999; background-image:url(\""+dataurl+"\")' onclick=' $(this).remove(); '></div>")
-	}
-	
-	(function(console){
-		/**
-		 * Convenient storing large data objects (json, dataUri, base64 encoded images, ...) from the console.
-		 * 
-		 * @param {object} data to save (means download)
-		 * @param {string} filename used for download
-		 * @returns {undefined}
-		 */
-		console.save = function(data, filename){
-
-			if(!data) {
-				console.error('Console.save: No data')
-				return;
-			}
-
-			if(!filename) filename = 'console.json'
-
-			if(typeof data === "object"){
-				data = JSON.stringify(data, undefined, 4)
-			}
-
-			var blob = new Blob([data], {type: 'text/json'}),
-				e    = document.createEvent('MouseEvents'),
-				a    = document.createElement('a')
-
-			a.download = filename
-			a.href = window.URL.createObjectURL(blob)
-			a.dataset.downloadurl =  ['text/json', a.download, a.href].join(':')
-			e.initMouseEvent('click', true, false, window, 0, 0, 0, 0, 0, false, false, false, false, 0, null)
-			a.dispatchEvent(e)
-		}
-	})(console)
+		new PNotify({
+			title: "render debug output " + target,
+			text: dbg_link,
+			type: "warn",
+			hide: false
+		});
 }
+
+function show_in_popup(dataurl) {
+	$('#debug_rendering_div').remove();
+	$('body').append("<div id='debug_rendering_div' style='position:fixed; top:0; left:0; border:1px solid red; background:center no-repeat; background-size: contain; background-color:aqua; width:50vw; height:50vh; z-index:999999; background-image:url(\""+dataurl+"\")' onclick=' $(this).remove(); '></div>")
+}
+
+(function(console){
+	/**
+	 * Convenient storing large data objects (json, dataUri, base64 encoded images, ...) from the console.
+	 * 
+	 * @param {object} data to save (means download)
+	 * @param {string} filename used for download
+	 * @returns {undefined}
+	 */
+	console.save = function(data, filename){
+
+		if(!data) {
+			console.error('Console.save: No data')
+			return;
+		}
+
+		if(!filename) filename = 'console.json'
+
+		if(typeof data === "object"){
+			data = JSON.stringify(data, undefined, 4)
+		}
+
+		var blob = new Blob([data], {type: 'text/json'}),
+			e    = document.createEvent('MouseEvents'),
+			a    = document.createElement('a')
+
+		a.download = filename
+		a.href = window.URL.createObjectURL(blob)
+		a.dataset.downloadurl =  ['text/json', a.download, a.href].join(':')
+		e.initMouseEvent('click', true, false, window, 0, 0, 0, 0, 0, false, false, false, false, 0, null)
+		a.dispatchEvent(e)
+	}
+})(console)
+// End Render debugging utilities
 
 $(function(){
 
@@ -2243,7 +2244,7 @@ $(function(){
 					if (typeof callback === 'function') {
 						callback(svg);
 						if (MRBEAM_DEBUG_RENDERING) {
-							const data = {fillImg: '(' + w + ',' + h + '@' + x + ',' + y + ' mm)'}
+							const data = {width: w, height:h, x:x, y:y};
 							debugBase64(svg.toDataURL(), 'Step 3: SVG with fill rendering', data);
 						}
 					}
@@ -2252,12 +2253,7 @@ $(function(){
 
 				let renderBBoxMM = tmpSvg.getBBox(); // if #712 still fails, fetch this bbox earlier (getCompositionSvg()).
 				if(MRBEAM_DEBUG_RENDERING){
-////					var base64String = btoa(tmpSvg.innerSVG());
-//					var raw = tmpSvg.innerSVG();
-//					var svgString = raw.substr(raw.indexOf('<svg'));
-//					var dataUrl = 'data:image/svg+xml;base64, ' + btoa(svgString);
-					const bbStr = '(' + renderBBoxMM.width + ',' + renderBBoxMM.height + '@' + renderBBoxMM.x + ',' + renderBBoxMM.y + ' mm)' 
-					debugBase64(tmpSvg.toDataURL(), 'Step 1: SVG ready for canvas, renderBBox', bbStr);
+					debugBase64(tmpSvg.toDataURL(), 'Step 1: SVG ready for canvas, renderBBox', renderBBoxMM);
 				}
 				console.log("Rendering " + fillings.length + " filled elements.");
 				if(fillAreas){

--- a/octoprint_mrbeam/static/js/working_area.js
+++ b/octoprint_mrbeam/static/js/working_area.js
@@ -319,7 +319,7 @@ $(function(){
 					data: JSON.stringify({"command": "position", x:parseFloat(x.toFixed(2)), y:parseFloat(y.toFixed(2))})
 				});
 			} else {
-				console.warn("Move Laser command while machine state not idle: " + self.state.stateString());
+				console.warn("Move Laser to "+x+","+y+" command while machine state not idle: " + self.state.stateString());
 			}
 		};
 

--- a/octoprint_mrbeam/static/js/working_area.js
+++ b/octoprint_mrbeam/static/js/working_area.js
@@ -3,58 +3,7 @@
 MRBEAM_PX2MM_FACTOR_WITH_ZOOM = 1; // global available in this viewmodel and in snap plugins at the same time.
 
 // Render debugging utilities
-MRBEAM_DEBUG_RENDERING = true;
-function debugBase64(base64URL, target="", data=null) {
-	var dbg_link = "<a target='_blank' href='"+base64URL+"' onmouseover=' show_in_popup(\""+base64URL+"\"); '>Hover | Right click -> Open in new tab</a>"; // debug message, no need to translate
-	if(data){
-		dbg_link += "<br/>" + JSON.stringify(data);
-	}
-		new PNotify({
-			title: "render debug output " + target,
-			text: dbg_link,
-			type: "warn",
-			hide: false
-		});
-}
-
-function show_in_popup(dataurl) {
-	$('#debug_rendering_div').remove();
-	$('body').append("<div id='debug_rendering_div' style='position:fixed; top:0; left:0; border:1px solid red; background:center no-repeat; background-size: contain; background-color:aqua; width:50vw; height:50vh; z-index:999999; background-image:url(\""+dataurl+"\")' onclick=' $(this).remove(); '></div>")
-}
-
-(function(console){
-	/**
-	 * Convenient storing large data objects (json, dataUri, base64 encoded images, ...) from the console.
-	 * 
-	 * @param {object} data to save (means download)
-	 * @param {string} filename used for download
-	 * @returns {undefined}
-	 */
-	console.save = function(data, filename){
-
-		if(!data) {
-			console.error('Console.save: No data')
-			return;
-		}
-
-		if(!filename) filename = 'console.json'
-
-		if(typeof data === "object"){
-			data = JSON.stringify(data, undefined, 4)
-		}
-
-		var blob = new Blob([data], {type: 'text/json'}),
-			e    = document.createEvent('MouseEvents'),
-			a    = document.createElement('a')
-
-		a.download = filename
-		a.href = window.URL.createObjectURL(blob)
-		a.dataset.downloadurl =  ['text/json', a.download, a.href].join(':')
-		e.initMouseEvent('click', true, false, window, 0, 0, 0, 0, 0, false, false, false, false, 0, null)
-		a.dispatchEvent(e)
-	}
-})(console)
-// End Render debugging utilities
+MRBEAM_DEBUG_RENDERING = false; // setting to true enables lots of visual debug tools. Can be changed during runtime. 
 
 $(function(){
 
@@ -1891,7 +1840,7 @@ $(function(){
 				var viewBox = "0 0 " + wMM + " " + hMM;
 
 				svgStr = WorkingAreaHelper.fix_svg_string(svgStr); // Firefox bug workaround.
-				var gc_otions_str = self.gc_options_as_string().replace('"', "'");
+				const gc_options_str = self.gc_options_as_string().replace(/"/g, "\"");
 
 				// ensure namespaces are present
 				namespaces['xmlns'] = "http://www.w3.org/2000/svg";
@@ -1899,8 +1848,8 @@ $(function(){
 				let nsList = Object.keys(namespaces).map(key => `${key}="${namespaces[key]}"`).join(" ");
 				var svg = `
 <svg version="1.1" ${nsList} 
-  mb:beamOS_version="${BEAMOS_VERSION}" mb:browser="${navigator.userAgent}"
-  width="${w}" height="${h}"  viewBox="${viewBox}" mb:gc_options="${gc_otions_str}">
+  mb:beamOS_version="${BEAMOS_VERSION}"
+  width="${w}" height="${h}"  viewBox="${viewBox}" mb:gc_options="${gc_options_str}">
 <defs/>
   ${svgStr}
 </svg>`;
@@ -1920,6 +1869,7 @@ $(function(){
 			for (var key in gc_options) {
 				res.push(key + ":" + gc_options[key]);
 			}
+			res.push('userAgent:'+navigator.userAgent.replace(/"/g,'\"'));
 			return res.join(", ");
 		};
 


### PR DESCRIPTION
Finally fixed. Safari based browsers act bogus on canvas.drawImage(..) when src_x or src_y are negative. 
More changes:
- fixed "is no property ... of undefined" errors (path_magic.js)
- logs the amount of clipped nodes during vector conversion (path_magic.js)
- fixed console.log output (render_fills.js)
- moved magic numbers to parameters in bbox enlarging code (render_fills.js)
- assert that enlarged bbox has no negative coordinates / offsets
- debugging helpers:
  - new debug_rendering_helper.js containing functions which were in working_area.js before
  - MR_BEAM_DEBUG_RENDERING global can now be switched during runtime
  - easier visibility of debugged dataurls (popup in addition to right-click open in tab)
  - renderCanvas visible if set to true.
  - console.save(data) always available for downloading large data objects (like 5MB dataURLs)
