### PR TITLE
Analytics: add errors and warnings from Chrome dev console

### DIFF
--- a/octoprint_mrbeam/analytics/analytics_handler.py
+++ b/octoprint_mrbeam/analytics/analytics_handler.py
@@ -35,7 +35,7 @@ def analyticsHandler(plugin):
 
 class AnalyticsHandler(object):
 	QUEUE_MAXSIZE = 1000
-	ANALYTICS_LOG_VERSION = 13  # bumped in 0.6.9.1 for cam image upload
+	ANALYTICS_LOG_VERSION = 14  # bumped in 0.6.10.1 for frontend console logs
 
 	def __init__(self, plugin):
 		self._plugin = plugin

--- a/octoprint_mrbeam/static/js/mother_viewmodel.js
+++ b/octoprint_mrbeam/static/js/mother_viewmodel.js
@@ -54,6 +54,9 @@ $(function () {
                 return false;
             });
 
+
+            callXXXX()
+
             self.control.setCoordinateOrigin = function () {
                 self.control.sendCustomCommand({type: 'command', command: "G92 X0 Y0"});
             };

--- a/octoprint_mrbeam/static/js/mother_viewmodel.js
+++ b/octoprint_mrbeam/static/js/mother_viewmodel.js
@@ -54,9 +54,6 @@ $(function () {
                 return false;
             });
 
-
-            callXXXX()
-
             self.control.setCoordinateOrigin = function () {
                 self.control.sendCustomCommand({type: 'command', command: "G92 X0 Y0"});
             };

--- a/octoprint_mrbeam/templates/error_logging_script.jinja2
+++ b/octoprint_mrbeam/templates/error_logging_script.jinja2
@@ -1,37 +1,142 @@
-<script lang="javascript">
+<script lang="javascript" type="text/javascript">
 
     if (console.everything === undefined) {
         console.everything = [];
+        console.callbacks = {
+            debug: null,
+            log: null,
+            error: null,
+            warn: null,
+            trace: null,
+        }
+
+        console._logDataFromArgs = function(){
+            let c = console._getCaller(Array.from(arguments).join(' '))
+            if (c) {
+                // message is a stacktrace
+                return {
+                    "level": null,
+                    "msg": c.msg,
+                    "ts": Date.now(),
+                    "file": c ? c.file : null,
+                    "function": c? c.function: null,
+                    "line": c ? c.line : null,
+                    "col": c ? c.col : null,
+                    "stacktrace": c ? c.stacktrace : null,
+                    {#"rawStack": c ? c.rawStack : null,#}
+                }
+            }
+
+            let msg = []
+            for (let a of arguments) {
+                msg.push((typeof(a) === "object" && a !== null) ? JSON.stringify(a) : a)
+            }
+            c = console._getCaller()
+            return {
+                "level": null,
+                "msg": msg.join(' '),
+                "ts": Date.now(),
+                "file": c ? c.file : null,
+                "function": c? c.function: null,
+                "line": c ? c.line : null,
+                "col": c ? c.col : null,
+                "stacktrace": c ? c.stacktrace : null,
+                {#"rawStack": c ? c.rawStack : null,#}
+            }
+        }
+
+        console._STACK_FRAME_RE = /at (.*)\s?\(https?:\/+[^/]+\/*(\/.+):(\d+):(\d+)/
+        console._ERR_FILENAME = /https?:\/+[^/]+\/*(\/.+)/
+        console._getCaller = function(passedStack) {
+            try {
+                let stack = passedStack ? passedStack.split("\n") : (new Error()).stack.split("\n");
+                let rawStack = Array.from(stack)
+                let msg = stack.shift().trim()
+                let callerInfo = null
+                let stacktrace = []
+                let first = true
+                for(let frame of stack) {
+                    if (!frame.trim().startsWith('at console')) {
+                        if (first) {
+                            callerInfo = console._STACK_FRAME_RE.exec(frame);
+                        }
+                        stacktrace.push(frame.trim())
+                        first = false
+                    }
+                }
+                if (callerInfo) {
+                    return {
+                        function: callerInfo[1] || null,
+                        file: callerInfo[2] || null,
+                        line: callerInfo[3] || null,
+                        col: callerInfo[4] || null,
+                        msg: msg,
+                        stacktrace: stacktrace,
+                        {#rawStack: rawStack#}
+                    };
+                }
+                return null;
+            } catch (e) {
+                return null;
+            }
+          }
 
         console.defaultLog = console.log.bind(console);
         console.log = function(){
-            console.everything.push({"type":"log", "datetime":Date().toLocaleString(), "value":Array.from(arguments), "ts": Date.now()});
+            let data = console._logDataFromArgs.apply(null, arguments)
+            data.level = "log"
+            console.everything.push(data);
             console.defaultLog.apply(console, arguments);
+            if (console.callbacks.log) {console.callbacks.log(data);}
         }
         console.defaultError = console.error.bind(console);
         console.error = function(){
-            console.everything.push({"type":"error", "datetime":Date().toLocaleString(), "value":Array.from(arguments), "ts": Date.now()});
+            let data = console._logDataFromArgs.apply(null, arguments)
+            data.level = "error"
+            console.everything.push(data);
             console.defaultError.apply(console, arguments);
+            if (console.callbacks.error) {console.callbacks.error(data);}
         }
         console.defaultWarn = console.warn.bind(console);
         console.warn = function(){
-            console.everything.push({"type":"warn", "datetime":Date().toLocaleString(), "value":Array.from(arguments), "ts": Date.now()});
+            let data = console._logDataFromArgs.apply(null, arguments)
+            data.level = "warn"
+            console.everything.push(data);
             console.defaultWarn.apply(console, arguments);
+            if (console.callbacks.warn) {console.callbacks.warn(data);}
         }
         console.defaultDebug = console.debug.bind(console);
         console.debug = function(){
-            console.everything.push({"type":"debug", "datetime":Date().toLocaleString(), "value":Array.from(arguments), "ts": Date.now()});
+            let data = console._logDataFromArgs.apply(null, arguments)
+            data.level = "debug"
+            console.everything.push(data);
             console.defaultDebug.apply(console, arguments);
+            if (console.callbacks.debug) {console.callbacks.debug(data);}
         }
         console.defaultTrace = console.trace.bind(console);
         console.trace = function(){
-            console.everything.push({"type":"trace", "datetime":Date().toLocaleString(), "value":Array.from(arguments), "ts": Date.now()});
+            let data = console._logDataFromArgs.apply(null, arguments)
+            data.level = "trace"
+            console.everything.push(data);
             console.defaultTrace.apply(console, arguments);
+            if (console.callbacks.trace) {console.callbacks.trace(data);}
         }
     }
 
     window.addEventListener('error', function(event) {
-        console.error(event);
+        let m = console._ERR_FILENAME.exec(event.filename)
+        let filename = m ? m[1] : null
+        let data = {
+            "level":"error",
+            "msg": event.message,
+            "file": filename,
+            "function": "window.onerror",
+            "line": event.lineno,
+            "col": event.colno,
+            "ts": Date.now()
+        }
+        console.everything.push(data);
+        if (console.callbacks.error) {console.callbacks.error(data);}
         return false;
     })
 

--- a/octoprint_mrbeam/templates/error_logging_script.jinja2
+++ b/octoprint_mrbeam/templates/error_logging_script.jinja2
@@ -1,0 +1,38 @@
+<script lang="javascript">
+
+    if (console.everything === undefined) {
+        console.everything = [];
+
+        console.defaultLog = console.log.bind(console);
+        console.log = function(){
+            console.everything.push({"type":"log", "datetime":Date().toLocaleString(), "value":Array.from(arguments), "ts": Date.now()});
+            console.defaultLog.apply(console, arguments);
+        }
+        console.defaultError = console.error.bind(console);
+        console.error = function(){
+            console.everything.push({"type":"error", "datetime":Date().toLocaleString(), "value":Array.from(arguments), "ts": Date.now()});
+            console.defaultError.apply(console, arguments);
+        }
+        console.defaultWarn = console.warn.bind(console);
+        console.warn = function(){
+            console.everything.push({"type":"warn", "datetime":Date().toLocaleString(), "value":Array.from(arguments), "ts": Date.now()});
+            console.defaultWarn.apply(console, arguments);
+        }
+        console.defaultDebug = console.debug.bind(console);
+        console.debug = function(){
+            console.everything.push({"type":"debug", "datetime":Date().toLocaleString(), "value":Array.from(arguments), "ts": Date.now()});
+            console.defaultDebug.apply(console, arguments);
+        }
+        console.defaultTrace = console.trace.bind(console);
+        console.trace = function(){
+            console.everything.push({"type":"trace", "datetime":Date().toLocaleString(), "value":Array.from(arguments), "ts": Date.now()});
+            console.defaultTrace.apply(console, arguments);
+        }
+    }
+
+    window.addEventListener('error', function(event) {
+        console.error(event);
+        return false;
+    })
+
+</script>

--- a/octoprint_mrbeam/templates/mrbeam_ui_index.jinja2
+++ b/octoprint_mrbeam/templates/mrbeam_ui_index.jinja2
@@ -14,6 +14,8 @@
         <link rel="apple-touch-icon" sizes="114x114" href="{{ url_for('plugin.mrbeam.static', filename='img/mrb114.png') }}">
         <link rel="apple-touch-icon" sizes="144x144" href="{{ url_for('plugin.mrbeam.static', filename='img/mrb144.png') }}">
 
+        {% include 'error_logging_script.jinja2' %}
+
         {#  Dirty to have this (== body elements) in the head section.
            Chrome ends head-tag and opens body-tag which means that all following is in the page's bodey instead of the head  #}
         {% include 'loading_overlay.jinja2' %}


### PR DESCRIPTION
All console.error() and console.warn() are logged and added to analytics IF analytics are anabled.
console.everything holds an array  of all log messages since bootup (frontend)