### PR TITLE
embed_gc(): No exception if id is undefined

### DIFF
--- a/octoprint_mrbeam/static/js/snap_gc_plugin.js
+++ b/octoprint_mrbeam/static/js/snap_gc_plugin.js
@@ -81,7 +81,7 @@ Snap.plugin(function (Snap, Element, Paper, global) {
                     ];
                     var clip_tolerance = 0.1 * tolerance;
 
-                    if (id.toLowerCase().indexOf('debug') !== -1 || id.toLowerCase().indexOf('andytest') !== -1) {
+                    if (id && (id.toLowerCase().indexOf('debug') !== -1 || id.toLowerCase().indexOf('andytest') !== -1)) {
                         console.log("mrbeam.path.clip() id:'" + id + "'"
                             + ", paths: " + mrbeam.path.pp_paths(paths)
                             + ", clip:" + mrbeam.path.pp_paths(clip)


### PR DESCRIPTION
See #848 SVG circle (and other) without ID: do better handling #848
