### PR TITLE
Design store tab refreshes the iframe

### DIFF
--- a/octoprint_mrbeam/static/js/design_store.js
+++ b/octoprint_mrbeam/static/js/design_store.js
@@ -3,8 +3,8 @@ $(function () {
         let self = this;
         window.mrbeam.viewModels['designStore'] = self;
 
-        self.DESIGN_STORE_IFRAME_SRC = 'https://design-store-269610.appspot.com';  // Don't write a "/" at the end!!
-        //self.DESIGN_STORE_IFRAME_SRC = 'http://localhost:8080';
+        // self.DESIGN_STORE_IFRAME_SRC = 'https://design-store-269610.appspot.com';  // Don't write a "/" at the end!!
+        self.DESIGN_STORE_IFRAME_SRC = 'http://localhost:8080';
 
         self.loginState = params[0];
         self.navigation = params[1];
@@ -126,6 +126,12 @@ $(function () {
                     });
                 }
             });
+        };
+
+        self.goToStore = function () {
+            if($('#designstore_tab_btn').parent().hasClass("active")){
+                self.sendMessageToDesignStoreIframe('goToStore', {})
+            }
         }
     }
 

--- a/octoprint_mrbeam/static/js/design_store.js
+++ b/octoprint_mrbeam/static/js/design_store.js
@@ -3,8 +3,8 @@ $(function () {
         let self = this;
         window.mrbeam.viewModels['designStore'] = self;
 
-        // self.DESIGN_STORE_IFRAME_SRC = 'https://design-store-269610.appspot.com';  // Don't write a "/" at the end!!
-        self.DESIGN_STORE_IFRAME_SRC = 'http://localhost:8080';
+        self.DESIGN_STORE_IFRAME_SRC = 'https://design-store-269610.appspot.com';  // Don't write a "/" at the end!!
+        // self.DESIGN_STORE_IFRAME_SRC = 'http://localhost:8080';
 
         self.loginState = params[0];
         self.navigation = params[1];

--- a/octoprint_mrbeam/templates/mrbeam_ui_index.jinja2
+++ b/octoprint_mrbeam/templates/mrbeam_ui_index.jinja2
@@ -50,7 +50,7 @@
 					<li class="active"><a href="#workingarea" data-toggle="tab" id="wa_tab_btn">{{ _('working area') }}</a></li>
                     {# Translatots: Name of the tab #}
 					<li><a href="#designlib" data-toggle="tab" id="designlib_tab_btn">{{ _('design library') }}</a></li>
-                    <li class="experimental_feature_dev"><a href="#designstore" data-toggle="tab" id="designstore_tab_btn">{{ _('design store') }}</a></li>
+                    <li class="experimental_feature_dev"><a href="#designstore" data-toggle="tab" id="designstore_tab_btn" onclick="window.mrbeam.viewModels.designStore.goToStore()">{{ _('design store') }}</a></li>
                     {% if not enableFocus %}
 					<li><a href="#focus" data-toggle="tab" id="focus_tab_btn">{{ _('focus') }}</a></li>
                     {% endif %}


### PR DESCRIPTION
Refreshing the iframe made the page reload in a buggy and unclean sort of way. I solved this by sending a message (on click) to the design store front-end which will in its turn execute the function that returns the user to the design store from the single design page.