### PR TITLE
Save camera settings more often.

### DIFF
--- a/octoprint_mrbeam/iobeam/lid_handler.py
+++ b/octoprint_mrbeam/iobeam/lid_handler.py
@@ -748,10 +748,10 @@ class PhotoCreator(object):
 								 analytics,
 								 force_upload=(count_sent_pictures_analytics%10==0),
 								 notify_user=False)
+			self.save_camera_settings(markers=self.last_markers, shutter_speed=self.last_shutter_speed)
 
 		self.last_shutter_speed = cam.shutter_speed
 		cam.stop_preview()
-		self.save_camera_settings(markers=self.last_markers, shutter_speed=self.last_shutter_speed)
 		if session_details['num_pics'] > 0:
 			session_details.update({
 				'settings_min_marker_size': self._settings.get(['cam', 'markerRecognitionMinPixel']),


### PR DESCRIPTION
I'm afraid some users just turn it off in the middle of a camera session and the file doesn't get saved.