### PR TITLE
Fixes Exception in cpu data of analytics

### DIFF
--- a/octoprint_mrbeam/analytics/analytics_handler.py
+++ b/octoprint_mrbeam/analytics/analytics_handler.py
@@ -483,9 +483,10 @@ class AnalyticsHandler(object):
 		self._add_job_event(ak.Job.Event.Slicing.CANCELLED)
 
 	def _add_cpu_data(self, dur=None):
-		payload = self._current_cpu_data.get_cpu_data()
-		payload['dur'] = dur
-		self._add_job_event(ak.Job.Event.CPU, payload=payload)
+		if self._current_cpu_data:
+			payload = self._current_cpu_data.get_cpu_data()
+			payload['dur'] = dur
+			self._add_job_event(ak.Job.Event.CPU, payload=payload)
 
 	def _event_print_started(self, event, payload):
 		# If there's no job_id, it may be a gcode file (no slicing), so we have to start the job here


### PR DESCRIPTION
Exception:
```
2020-08-14 14:20:37,657 - octoprint.plugins.mrbeam.printing.acc_watch_dog - DEBUG - Stop
2020-08-14 14:20:37,658 - octoprint.events - ERROR - Got an exception while sending event PrintDone (Payload: {'origin': 'local', 'name': u'CalibrationMarkers.3.gco', 'file': u'/home/pi/.octoprint/uploads/CalibrationMarkers.3.gco', 'time': 92.29612708091736, 'path': u'CalibrationMarkers.3.gco', 'size': 3076L, 'filename': u'CalibrationMarkers.3.gco'}) to <bound method AnalyticsHandler._event_print_done of <octoprint_mrbeam.analytics.analytics_handler.AnalyticsHandler object at 0x74d26610>>
Traceback (most recent call last):
  File "/home/pi/oprint/local/lib/python2.7/site-packages/octoprint/events.py", line 162, in _work
    listener(event, payload)
  File "/home/pi/oprint/local/lib/python2.7/site-packages/octoprint_mrbeam/analytics/analytics_handler.py", line 564, in _event_print_done
    self._add_cpu_data(dur=payload['time'])
  File "/home/pi/oprint/local/lib/python2.7/site-packages/octoprint_mrbeam/analytics/analytics_handler.py", line 486, in _add_cpu_data
    payload = self._current_cpu_data.get_cpu_data()
AttributeError: 'NoneType' object has no attribute 'get_cpu_data'
2020-08-14 14:20:37,685 - octoprint.plugins.mrbeam.printing.comm_acc2 - DEBUG - _move_home() called
```