### PR TITLE
Fix: compressor slider was ignored fo any cutting job

### DIFF
--- a/octoprint_mrbeam/static/js/convert.js
+++ b/octoprint_mrbeam/static/js/convert.js
@@ -669,7 +669,7 @@ $(function(){
 				$(job).find('.param_passes').val(p.cut_p || 0);
 				$(job).find('.param_progressive').prop('checked', p.progressive);
 				$(job).find('.param_piercetime').val(p.cut_pierce || 0);
-				$(job).find('.compressor_range').val(p.cut_compressor || 0);  // Here we pass the value of the range (0), not the real one (10%)
+				$(job).find('.param_cut_compressor').val(p.cut_compressor || 0);  // Here we pass the value of the range (0), not the real one (10%)
 			}
 		};
 		self.apply_engraving_proposal = function(){
@@ -878,7 +878,7 @@ $(function(){
 				var piercetime = $(job).find('.param_piercetime').val();
 				var progressive = $(job).find('.param_progressive').prop('checked');
 				var passes = $(job).find('.param_passes').val();
-				let cut_compressor = $(job).find('.compressor_range').val();
+				let cut_compressor = $(job).find('.param_cut_compressor').val();
 
 				if (prepareForBackend) {
 				    cut_compressor = self.mapCompressorValue(cut_compressor);

--- a/octoprint_mrbeam/templates/conversion_dialog.jinja2
+++ b/octoprint_mrbeam/templates/conversion_dialog.jinja2
@@ -395,7 +395,7 @@
                                     <div class="controls range-control">
                                         <div class="compressor_control">
                                             <span class="compressor_min_max_label">min</span>
-                                            <input class="mrb_slider" type="range" min="0" max="3" value="3" data-bind="event: {change: flag_customized_material}"/>
+                                            <input class="mrb_slider param_cut_compressor" type="range" min="0" max="3" value="3" data-bind="event: {change: flag_customized_material}"/>
                                             <span class="compressor_min_max_label">max</span>
                                         </div>
                                     </div>


### PR DESCRIPTION
For any cutting job, the value of the slider was ignored. Any cutting job had the compressor value set to 10. Engraving jobs were not affected.