### PR TITLE
Show missing markers in gray when camera is inactive.

### DIFF
--- a/octoprint_mrbeam/static/css/svgtogcode.css
+++ b/octoprint_mrbeam/static/css/svgtogcode.css
@@ -526,6 +526,14 @@ g#camera_markers.markerSW circle#markerSW {
 	animation: blinker 2s linear infinite;
 }
 
+g#camera_markers.markerNE.gray circle#markerNE,
+g#camera_markers.markerSE.gray circle#markerSE,
+g#camera_markers.markerNW.gray circle#markerNW,
+g#camera_markers.markerSW.gray circle#markerSW {
+	opacity: .6;
+  animation: none;
+}
+
 @keyframes blinker {
   50% {
     opacity: 0;

--- a/octoprint_mrbeam/static/js/camera.js
+++ b/octoprint_mrbeam/static/js/camera.js
@@ -29,6 +29,7 @@ $(function(){
         self.isCamCalibrated = false;
         self.firstImageLoaded = false;
         self.countImagesLoaded = ko.observable(0);
+        self.imagesInSession = ko.observable(0);
 
         self.markersFound = ko.observable(new Map(MARKERS.map(elm => [elm, undefined])));
 
@@ -104,7 +105,15 @@ $(function(){
         })
 
         self.cameraActive = ko.computed(function() {
-            return self.firstRealimageLoaded() && self.state.isOperational() && !self.state.isPrinting() && !self.state.isLocked();
+            let ret = self.firstRealimageLoaded()
+                && self.state.isOperational()
+                && !self.state.isPrinting()
+                && !self.state.isLocked()
+                && !self.state.interlocksClosed();
+            if (!ret) {
+                self.imagesInSession(0);
+            }
+            return ret;
         })
 
         self.markerMissedClass = ko.computed(function() {
@@ -113,6 +122,14 @@ $(function(){
                 if ((self.markersFound()[m] !== undefined) && !self.markersFound()[m])
                     ret = ret + ' marker' + m;
             });
+            if (self.cameraMarkerElem !== undefined){
+                if (self.imagesInSession() == 0) {
+                    ret = ret + ' gray'
+                    // Somehow the filter in css doesn't work
+                    self.cameraMarkerElem.attr({style:"filter: url(#grayscale_filter)"});
+                } else
+                    self.cameraMarkerElem.attr({style:""});
+            }
             return ret;
         })
 
@@ -152,11 +169,6 @@ $(function(){
                 }
                 self.loadImage(self.croppedUrl);
             }
-
-			// If camera is not active (lid closed), all marker(NW|NE|SW|SE) classes should be removed.
-			if('interlocks_closed' in data && data.interlocks_closed === true){
-				self.cameraMarkerElem.attr('class', '');
-			}
         };
 
         self.loadImage = function (url) {
@@ -179,6 +191,7 @@ $(function(){
                 } else {
                     OctoPrint.simpleApiCommand("mrbeam", "on_camera_picture_transfer", {})
                 }
+                self.imagesInSession(self.imagesInSession()+1)
             });
             if (!self.firstImageLoaded) {
                 img.error(function () {

--- a/octoprint_mrbeam/static/js/mother_viewmodel.js
+++ b/octoprint_mrbeam/static/js/mother_viewmodel.js
@@ -158,6 +158,7 @@ $(function () {
 //            self.state.isReady = ko.observable(undefined); // not sure why this is injected here. should be already present in octoprints printerstate VM
             self.state.isFlashing = ko.observable(undefined);
             self.state.currentPos = ko.observable(undefined);
+            self.state.interlocksClosed = ko.observable(false);
 			self.state.filename = ko.observable(undefined);
 			self.state.filesize = ko.observable(undefined);
 			self.state.filepos = ko.observable(undefined);

--- a/octoprint_mrbeam/static/js/ready_to_laser_viewmodel.js
+++ b/octoprint_mrbeam/static/js/ready_to_laser_viewmodel.js
@@ -16,7 +16,6 @@ $(function () {
 		self.dialogTimeoutId = -1;
 		self.gcodeFile = undefined;
 
-		self.interlocks_closed = ko.observable(true);
 		self.is_cooling_mode = ko.observable(false);
 		self.is_fan_connected = ko.observable(true);
 		self.is_rtl_mode = ko.observable(false);
@@ -218,7 +217,7 @@ $(function () {
 					self.is_pause_mode(mrb_state['pause_mode']);
 				}
 				if ('interlocks_closed' in mrb_state) {
-					self.interlocks_closed(mrb_state['interlocks_closed']);
+					self.state.interlocksClosed(mrb_state['interlocks_closed']);
 				}
 				if ('lid_fully_open' in mrb_state) {
 					self.lid_fully_open(mrb_state['lid_fully_open']);

--- a/octoprint_mrbeam/templates/ready_to_laser.jinja2
+++ b/octoprint_mrbeam/templates/ready_to_laser.jinja2
@@ -1,6 +1,6 @@
 <div id="ready_to_laser_dialog" class="modal hide fade" data-backdrop="static">
 
-    <div data-bind='visible: !is_cooling_mode() || !interlocks_closed()'>
+    <div data-bind='visible: !is_cooling_mode() || !state.interlocksClosed()'>
         <div class="modal-header">
             <a href="#" class="close" data-bind='visible: is_rtl_mode(), click: cancel_btn' aria-hidden="true">&times;</a>
             <h3 data-bind='visible: is_rtl_mode()'>{{ _('Ready To Laser?') }}</h3>
@@ -8,22 +8,22 @@
         </div>
         <div class="modal-body">
             <img data-bind='visible: !is_fan_connected()' src="/plugin/mrbeam/static/img/airfilter.jpg">
-            <img data-bind='visible: !interlocks_closed() && is_fan_connected()' src="/plugin/mrbeam/static/img/closelid.jpg">
-            <img data-bind='visible: interlocks_closed() && is_fan_connected()' src="/plugin/mrbeam/static/img/onebutton.jpg">
+            <img data-bind='visible: !state.interlocksClosed() && is_fan_connected()' src="/plugin/mrbeam/static/img/closelid.jpg">
+            <img data-bind='visible: state.interlocksClosed() && is_fan_connected()' src="/plugin/mrbeam/static/img/onebutton.jpg">
             <h5 data-bind='visible: !is_fan_connected()'>{{ _('Can not detect air filter system. Is it plugged in?') }}</h5>
-            <h5 data-bind='visible: !interlocks_closed() && is_fan_connected()'>{{ _('Please close the lid completely before we can proceed.') }}</h5>
-            <h5 data-bind='visible: interlocks_closed() && is_fan_connected()'>{{ _('Everything is ready to go.') }}</h5>
-            <h5 data-bind='visible: interlocks_closed() && is_fan_connected() && is_rtl_mode()'>{{ _('Estimated duration') }}:<span data-bind="text: estimated_duration" style="font-size:1.2em"></span></h5>
+            <h5 data-bind='visible: !state.interlocksClosed() && is_fan_connected()'>{{ _('Please close the lid completely before we can proceed.') }}</h5>
+            <h5 data-bind='visible: state.interlocksClosed() && is_fan_connected()'>{{ _('Everything is ready to go.') }}</h5>
+            <h5 data-bind='visible: state.interlocksClosed() && is_fan_connected() && is_rtl_mode()'>{{ _('Estimated duration') }}:<span data-bind="text: estimated_duration" style="font-size:1.2em"></span></h5>
         </div>
         <div class="modal-footer">
             <a class="btn pull-left" data-bind='visible: is_rtl_mode(), click: cancel_btn' aria-hidden="true">{{ _('cancel') }}</a>
             <a class="btn pull-left" data-bind='visible: !is_rtl_mode(), click: cancel_btn' aria-hidden="true">{{ _('Cancel Laser Job') }}</a>
             <h4 class="pull-right" data-bind='visible: !is_fan_connected()'>{{ _('Plug in air filter system') }}</h4>
-            <h4 class="pull-right" data-bind='visible: !interlocks_closed() && is_fan_connected()'>{{ _('Close the lid') }}</h4>
-            <h4 id="ready_to_laser_dev_start_btn" class="pull-right dev_start_button" data-bind='visible: interlocks_closed() && is_fan_connected() && is_rtl_mode()'>
+            <h4 class="pull-right" data-bind='visible: !state.interlocksClosed() && is_fan_connected()'>{{ _('Close the lid') }}</h4>
+            <h4 id="ready_to_laser_dev_start_btn" class="pull-right dev_start_button" data-bind='visible: state.interlocksClosed() && is_fan_connected() && is_rtl_mode()'>
                 {{ _('Press the button to start') }}
             </h4>
-            <h4 id="ready_to_laser_dev_resume_btn" class="pull-right dev_start_button" data-bind='visible: interlocks_closed() && is_fan_connected() && !is_rtl_mode()'>
+            <h4 id="ready_to_laser_dev_resume_btn" class="pull-right dev_start_button" data-bind='visible: state.interlocksClosed() && is_fan_connected() && !is_rtl_mode()'>
                 {{ _('Press the button to continue') }}
             </h4>
             {#                <span class="dev_start_button" id="ready_to_laser_dev_start_btn" data-bind='visible: is_rtl_mode()'>{{ _('start') }}</span>#}
@@ -31,7 +31,7 @@
         </div>
     </div>
 
-    <div data-bind='visible: is_cooling_mode() && interlocks_closed()'>
+    <div data-bind='visible: is_cooling_mode() && state.interlocksClosed()'>
         <div class="modal-header">
             <h3 >{{ _('Cooling') }}</h3>
         </div>
@@ -47,8 +47,8 @@
         </div>
         <div class="modal-footer">
             <a class="btn pull-left" data-bind='click: cancel_btn' aria-hidden="true">{{ _('Cancel Laser Job') }}</a>
-            <h4 class="pull-right" data-bind='visible: !interlocks_closed()'>{{ _('Close the lid') }}</h4>
-            <h4 class="pull-right" data-bind='visible: interlocks_closed'>{{ _('Just relax') }}</h4>
+            <h4 class="pull-right" data-bind='visible: !state.interlocksClosed()'>{{ _('Close the lid') }}</h4>
+            <h4 class="pull-right" data-bind='visible: state.interlocksClosed'>{{ _('Just relax') }}</h4>
         </div>
     </div>
 

--- a/octoprint_mrbeam/templates/tab_workingarea.jinja2
+++ b/octoprint_mrbeam/templates/tab_workingarea.jinja2
@@ -744,7 +744,7 @@
 										<path d="M-15,0H-5M15,0H5M0,15V5M0,-15V-5" />
 									</g>
 									<g id="camera_markers" fill="#ffffff" stroke="#ff00ff" stroke-width="5"
-									   data-bind="visible: camera.cameraActive(), attr: { class: camera.markerMissedClass() }">
+									   data-bind="attr: { class: camera.markerMissedClass() }">
                                         <circle id="markerNW" r="5" cx="7" cy="7">
                                             <title>{{ _('The system can not find the pink marker in the device in this corner of the workin area. Please make sure that it is visible for the camera.') }}</title>
                                         </circle>

--- a/octoprint_mrbeam/templates/tab_workingarea.jinja2
+++ b/octoprint_mrbeam/templates/tab_workingarea.jinja2
@@ -73,7 +73,7 @@
 											</div>
 											<div class="collapse" id="wa_view_settings_body">
 												<div class="accordion-inner">
-                                                    <div data-bind="visible: camera.cameraActive() && camera.showMarkerWarning">
+                                                    <div data-bind="visible: camera.showMarkerWarning">
 
                                                         <div>
                                                             <p style="display: inline-block">


### PR DESCRIPTION
Fixes #948

Previously missed markers are not stored in backend -> Reboot or even refresh will get rid of them and the warning.

I kept it quite discrete, no blinking.
![Screenshot from 2020-09-03 14-15-22](https://user-images.githubusercontent.com/24782867/92113712-029d0400-edf0-11ea-9f77-1c639b47d8b1.png)
