### PR TITLE
DS menu item error fix

### DIFF
--- a/octoprint_mrbeam/templates/mrbeam_ui_index.jinja2
+++ b/octoprint_mrbeam/templates/mrbeam_ui_index.jinja2
@@ -51,7 +51,7 @@
 					<li class="active"><a href="#workingarea" data-toggle="tab" id="wa_tab_btn">{{ _('working area') }}</a></li>
                     {# Translatots: Name of the tab #}
 					<li><a href="#designlib" data-toggle="tab" id="designlib_tab_btn">{{ _('design library') }}</a></li>
-                    <li class="experimental_feature_beta"><a href="#designstore" data-toggle="tab" id="designstore_tab_btn" onclick="window.mrbeam.viewModels.designStore.goToStore()">{{ _('design store') }}</a></li>
+                    <li class="experimental_feature_beta"><a href="#designstore" data-toggle="tab" id="designstore_tab_btn" onclick="window.mrbeam.viewModels.designStoreViewModel.goToStore()">{{ _('design store') }}</a></li>
                     {% if not enableFocus %}
 					<li><a href="#focus" data-toggle="tab" id="focus_tab_btn">{{ _('focus') }}</a></li>
                     {% endif %}


### PR DESCRIPTION
While in the Design store, whenever the "Design store" menu item is clicked, the design store should be showing the design listing instead of a single design page. On click, nothing happens and an error shows in the console.