### PR TITLE
Fix warning for corner calibration.

### DIFF
--- a/octoprint_mrbeam/__init__.py
+++ b/octoprint_mrbeam/__init__.py
@@ -2319,6 +2319,7 @@ class MrBeamPlugin(
             self._hostname,
             check_calibration_tool_mode(self),
         )
+        self.lid_handler.refresh_settings()
         return NO_CONTENT
 
     ##~~ SlicerPlugin API

--- a/octoprint_mrbeam/camera/config.py
+++ b/octoprint_mrbeam/camera/config.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+from __future__ import absolute_import
+
+from collections import Mapping
+import numpy as np
+from octoprint_mrbeam.util import dict_map
+import yaml
+
+from .definitions import (
+    CALIB_REFS,
+    QD_KEYS,
+    FACT_UNDIST_CALIB_MARKERS_KEY,
+    FACT_UNDIST_CORNERS_KEY,
+    UNDIST_CALIB_MARKERS_KEY,
+    UNDIST_CORNERS_KEY,
+)
+
+"""
+Relates the config files in use for the camera.
+pic_settings.yaml : stores information from the corner calibration
+lens_calibration_xxxx_yyyy.npz : Stores the info for the lens calibration.
+Can take different names for the different calibrations made (factory vs user calibration)
+"""
+
+
+def is_lens_calibration_file(path):
+    try:
+        _conf = np.load(path)
+    except Exception:
+        return False
+    else:
+        return all(k in _conf.keys() for k in ("mtx", "dist"))
+
+
+def is_corner_calibration_map(_map):
+    assert isinstance(_map, Mapping)
+
+    def is_qd_map(qdDict):
+        return isinstance(qdDict, Mapping) and all(
+            qd in qdDict
+            and len(qdDict[qd]) == 2
+            and all(not x is None for x in qdDict[qd])
+            for qd in QD_KEYS
+        )
+
+    return is_qd_map(_map["corners"]) and is_qd_map(_map["markers"])
+
+
+def get_corner_calibration(settings):
+    # Values taken from the settings map. Used as a reference to warp the image correctly.
+    # Legacy devices only have the values for the lensCorrected position.
+    return dict_map(lambda key: settings.get(key, None), CALIB_REFS)
+
+
+def is_corner_calibration(conf_map, config_type="factory", origin_picture="raw"):
+    _conf = {
+        edge_type: conf_map[edge_type][config_type][origin_picture]
+        for edge_type in ("corners", "markers")
+    }
+    return is_corner_calibration_map(_conf)
+
+
+def calibration_available(
+    corner_config,
+    lens_calibration_file_path=None,
+    config_type="factory",
+    origin_picture="raw",
+):
+    if origin_picture == "raw":
+        # The lens calibration here is only optional.
+        return is_corner_calibration(corner_config, config_type, origin_picture)
+    else:
+        return (
+            is_corner_calibration(corner_config, config_type, origin_picture)
+            and lens_calibration_file_path is not None
+            and is_lens_calibration_file(lens_calibration_file_path)
+        )
+
+
+def calibration_needed(
+    corner_conf, calibration_file_factory=None, calibration_file_user=None
+):
+    """Determine whether a corner calibration is required.
+    Uses the config file (pic_settings.yaml) and optionnaly the lens calibration files"""
+    for config_type in ("user", "factory"):
+        if is_corner_calibration(corner_conf, config_type, origin_picture="raw"):
+            return False
+    # now we need to know if both the lens undistorted corner calibration has been done,
+    # and if the lens undistortion file is present. Both would be needed to correct the picture.
+    origin_picture = "undistorted"
+    if calibration_file_factory is not None and calibration_available(
+        corner_conf, calibration_file_factory, "factory", origin_picture
+    ):
+        return False
+    if calibration_file_user is not None and calibration_available(
+        corner_conf, calibration_file_user, "user", origin_picture
+    ):
+        return False
+    return True
+
+
+def calibration_needed_from_file(
+    config_path, calibration_file_factory=None, calibration_file_user=None
+):
+    try:
+        with open(config_path) as f:
+            corner_conf = get_corner_calibration(yaml.load(f))
+    except IOError:
+        return True
+    else:
+        return calibration_needed(
+            corner_conf, calibration_file_factory, calibration_file_user
+        )
+
+
+def calibration_needed_from_flat(
+    flat_corner_conf, calibration_file_factory=None, calibration_file_user=None
+):
+    """The pic_settings yaml file is written as mostly a shallow map."""
+    corner_conf = get_corner_calibration(flat_corner_conf)
+    return calibration_needed(
+        corner_conf, calibration_file_factory, calibration_file_user
+    )
+
+
+def rm_undistorted_keys(flat_corner_conf, factory=False):
+    """
+    Remove the keys and values for the undistorted marker/arrow
+    positions saved during the corner calibration.
+    """
+    flat_corner_conf = get_corner_calibration(flat_corner_conf)
+    if factory:
+        keys = [FACT_UNDIST_CALIB_MARKERS_KEY, FACT_UNDIST_CORNERS_KEY]
+    else:
+        keys = [UNDIST_CALIB_MARKERS_KEY, UNDIST_CORNERS_KEY]
+    for k in keys:
+        if k in flat_corner_conf.keys():
+            flat_corner_conf.pop(k)
+    return flat_corner_conf

--- a/octoprint_mrbeam/camera/config.py
+++ b/octoprint_mrbeam/camera/config.py
@@ -26,7 +26,7 @@ Can take different names for the different calibrations made (factory vs user ca
 def is_lens_calibration_file(path):
     try:
         _conf = np.load(path)
-    except Exception:
+    except (IOError, ValueError):
         return False
     else:
         return all(k in _conf.keys() for k in ("mtx", "dist"))

--- a/octoprint_mrbeam/camera/config.py
+++ b/octoprint_mrbeam/camera/config.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 
 from collections import Mapping
 import numpy as np
-from octoprint_mrbeam.util import dict_map
+from octoprint_mrbeam.util import dict_map, dict_get
 import yaml
 
 from .definitions import (
@@ -54,7 +54,7 @@ def get_corner_calibration(settings):
 
 def is_corner_calibration(conf_map, config_type="factory", origin_picture="raw"):
     _conf = {
-        edge_type: conf_map[edge_type][config_type][origin_picture]
+        edge_type: dict_get(conf_map, [edge_type, config_type, origin_picture], None)
         for edge_type in ("corners", "markers")
     }
     return is_corner_calibration_map(_conf)

--- a/octoprint_mrbeam/camera/corners.py
+++ b/octoprint_mrbeam/camera/corners.py
@@ -113,9 +113,6 @@ def save_corner_calibration(
 
     pic_settings[__CORNERS_KEY] = newCorners
     pic_settings[__MARKERS_KEY] = newMarkers
-    pic_settings[
-        "calibration_updated"
-    ] = True  # DEPRECATED but Necessary for legacy algo
     if hostname:
         pic_settings["hostname_KEY"] = hostname
     write_corner_calibration(pic_settings, path)
@@ -150,31 +147,6 @@ def get_corner_calibration(pic_settings):
         return None
 
 
-def need_corner_calibration(pic_settings):
-    # pic settings : path (str) or dict, for now just dict
-    return all(
-        [
-            not calibration_available(pic_settings, undistorted)
-            for undistorted in (True, False)
-        ]
-    )
-
-
-def need_raw_corner_calibration(pic_settings):
-    return not calibration_available(pic_settings, undistorted=False)
-
-
-def calibration_available(pic_settings, undistorted):
-    """
-    Is there a calibration value for the markers for
-    the raw or for undistorted picture?
-    """
-    if pic_settings is None:
-        return False
-    _, ref, _ = get_deltas_and_refs(pic_settings, undistorted)
-    return ref is not None
-
-
 def get_deltas_and_refs(
     settings,
     undistorted=False,
@@ -204,19 +176,9 @@ def get_deltas_and_refs(
             return None
     else:
         pic_settings = settings
-    for k in [UNDIST_CALIB_MARKERS_KEY, UNDIST_CORNERS_KEY]:
-        if not (k in pic_settings and _isValidQdDict(pic_settings[k])):
-            pic_settings[k] = None
-        elif k in pic_settings.keys() and pic_settings[k] is not None:
-            for qd in QD_KEYS:
-                pic_settings[k][qd] = np.array(pic_settings[k][qd])
 
     # Values taken from the calibration file. Used as a reference to warp the image correctly.
     # Legacy devices only have the values for the lensCorrected position.
-    # FIXME move current lensCorrected cornerCalibration to the cornerCalibrationFromFactory
-    #       (can be safely deleted once the user did 1 corner calibration on a raw picture)
-    # warp image
-    # TODO
     calibrationReferences = dict_map(
         lambda key: pic_settings.get(key, None), CALIB_REFS
     )
@@ -236,7 +198,7 @@ def get_deltas_and_refs(
                     and dist is not None
                 ):
                     # Distort reference points
-                    ref["result"] = undist_dict(ref[k]["raw"])
+                    ref["result"] = lens.undist_dict(ref[k]["raw"])
                     break  # no need to go further in the priority list
                 elif ref[k]["undistorted"]:
                     ref["result"] = dict_map(np.array, ref[k]["undistorted"])
@@ -292,30 +254,3 @@ def add_deltas(markers, pic_settings, undistorted, *args, **kwargs):
             return None
         else:
             return {qd: markers[qd] + deltas[qd] for qd in QD_KEYS}
-
-
-def rm_undidtorted_keys(pic_settings, factory=False):
-    """
-    Remove the keys and values for the undistorted marker/arrow
-    positions saved during the corner calibration.
-    """
-    pic_settings = get_corner_calibration(pic_settings)
-    if factory:
-        keys = [FACT_UNDIST_CALIB_MARKERS_KEY, FACT_UNDIST_CORNERS_KEY]
-    else:
-        keys = [UNDIST_CALIB_MARKERS_KEY, UNDIST_CORNERS_KEY]
-    for k in keys:
-        if k in pic_settings.keys():
-            pic_settings.pop(k)
-    return pic_settings
-
-
-def _isValidQdDict(qdDict):
-    """
-    :param: qd-Dict to test for valid Keys
-    :returns True or False
-    """
-    return type(qdDict) is dict and all(
-        qd in qdDict and len(qdDict[qd]) == 2 and all(not x is None for x in qdDict[qd])
-        for qd in QD_KEYS
-    )

--- a/octoprint_mrbeam/camera/corners.py
+++ b/octoprint_mrbeam/camera/corners.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 
 from collections import Mapping
-from copy import deepcopy
 import yaml
 
 from .definitions import (
@@ -168,8 +167,6 @@ def get_deltas_and_refs(
     :param path_to_last_markers_json: needed for overwriting file if updated
     :return: pic_settings as dict
     """
-    from octoprint_mrbeam.camera.lens import undist_points
-
     if type(settings) is str:
         pic_settings = get_corner_calibration(settings)
         if pic_settings is None:

--- a/octoprint_mrbeam/camera/definitions.py
+++ b/octoprint_mrbeam/camera/definitions.py
@@ -89,16 +89,10 @@ RAW_CORNERS_KEY = "raw_cornersFromImage"
 FACT_UNDIST_CORNERS_KEY = "factory_undist_cornersFromImage"
 FACT_RAW_CORNERS_KEY = "factory_raw_cornersFromImage"
 
-# Calibration File : DEPRECATED keys
-M2C_VECTOR_KEY = "marker2cornerVecs"  # DEPRECATED Key
-CALIBRATION_UPDATED_KEY = "calibration_updated"
-BLUR_FACTOR_THRESHOLD_KEY = "blur_factor_threshold"
-
 # Empty settings config
 PIC_SETTINGS = {
     UNDIST_CALIB_MARKERS_KEY: None,
     UNDIST_CORNERS_KEY: None,
-    CALIBRATION_UPDATED_KEY: False,
 }
 CALIB_REFS = dict(
     markers=dict(

--- a/octoprint_mrbeam/camera/undistort.py
+++ b/octoprint_mrbeam/camera/undistort.py
@@ -209,9 +209,6 @@ def prepareImage(
     # load pic_settings json
     if pic_settings is None:
         return None, markers, missed, ERR_NEED_CALIB, outputPoints, savedPics
-    if corners.need_corner_calibration(pic_settings):
-        logger.warning(ERR_NEED_CALIB)
-        return None, markers, missed, ERR_NEED_CALIB, outputPoints, savedPics
 
     workspaceCorners = corners.add_deltas(
         markers, pic_settings, do_undistortion, cam_matrix, cam_dist, new_mtx=dest_mtx

--- a/octoprint_mrbeam/iobeam/lid_handler.py
+++ b/octoprint_mrbeam/iobeam/lid_handler.py
@@ -46,7 +46,7 @@ from octoprint_mrbeam.camera.undistort import (
     _getCamParams,
     prepareImage,
 )
-from octoprint_mrbeam.camera import corners
+from octoprint_mrbeam.camera import corners, config
 from octoprint_mrbeam.camera.lens import (
     BoardDetectorDaemon,
     FACTORY,
@@ -179,23 +179,7 @@ class LidHandler(object):
                 "onEvent() CLIENT_OPENED sending client lidClosed: %s", self._lid_closed
             )
             self._client_opened = True
-            pic_settings = get_corner_calibration(
-                self._settings.get(["cam", "correctionSettingsFile"])
-            )
-
-            self._plugin_manager.send_plugin_message(
-                "mrbeam",
-                dict(
-                    need_camera_calibration=corners.need_corner_calibration(
-                        pic_settings
-                    ),
-                    need_raw_camera_calibration=corners.need_raw_corner_calibration(
-                        pic_settings
-                    ),
-                ),
-            )
-            if corners.need_corner_calibration(pic_settings):
-                self._logger.warning(ERR_NEED_CALIB)
+            self.tell_client_calibration_status()
             self._startStopCamera(event)
         # Please re-enable when the OctoPrint is more reliable at
         # detecting when a user actually disconnected.
@@ -346,6 +330,44 @@ class LidHandler(object):
     def refresh_settings(self):
         # Let's the worker know to refresh the picture settings while running
         self._photo_creator.refresh_pic_settings.set()
+        self.tell_client_calibration_status()
+
+    def need_corner_calibration(self, pic_settings=None):
+        args = (
+            self._settings.get(["cam", "lensCalibration", "legacy"]),
+            self._settings.get(["cam", "lensCalibration", "user"]),
+        )
+        if pic_settings is None:
+            return config.calibration_needed_from_file(
+                self._settings.get(["cam", "correctionSettingsFile"]), *args
+            )
+        else:
+            return config.calibration_needed_from_flat(pic_settings, *args)
+
+    def tell_client_calibration_status(self):
+        try:
+            with open(self._settings.get(["cam", "correctionSettingsFile"])) as f:
+                pic_settings = yaml.load(f)
+        except IOError:
+            need_corner_calibration = True
+            need_raw_camera_calibration = True
+            pic_settings = None
+        else:
+            need_corner_calibration = self.need_corner_calibration(pic_settings)
+            need_raw_camera_calibration = config.calibration_needed_from_flat(
+                pic_settings
+            )
+        # self._logger.warning("pic settings %s", pic_settings)
+
+        self._plugin_manager.send_plugin_message(
+            "mrbeam",
+            dict(
+                need_camera_calibration=need_corner_calibration,
+                need_raw_camera_calibration=need_raw_camera_calibration,
+            ),
+        )
+        if need_corner_calibration:
+            self._logger.warning(ERR_NEED_CALIB)
 
     def get_calibration_file(self, calibration_type=None):
         """Gives the location of the best existing lens calibration file, or
@@ -530,14 +552,14 @@ class LidHandler(object):
         # Remove the lens distorted corner calibration keys
         pic_settings_path = self._settings.get(["cam", "correctionSettingsFile"])
         pic_settings = corners.get_corner_calibration(pic_settings_path)
-        corners.rm_undidtorted_keys(
+        config.rm_undistorted_keys(
             pic_settings, factory=self._plugin.calibration_tool_mode
         )
         corners.write_corner_calibration(
             pic_settings,
             pic_settings_path,
         )
-        if corners.need_corner_calibration(pic_settings):
+        if self.need_corner_calibration(pic_settings):
             self._logger.warning(ERR_NEED_CALIB)
             self._plugin_manager.send_plugin_message(
                 "mrbeam", dict(need_camera_calibration=True)
@@ -945,11 +967,14 @@ class PhotoCreator(object):
                     prev = latest
                     self._front_ready.set()
                 else:
-                    time.sleep(
-                        0.8
-                    )  # Let the raspberry breathe a bit (prevent overheating)
+                    # Let the raspberry breathe a bit (prevent overheating)
+                    time.sleep(0.8)
                     continue
 
+            if self._plugin.lid_handler.need_corner_calibration():
+                # triggers missing calibration warning while still taking a raw picture
+                # which is necessary if you want to calibrate the camera.
+                pic_settings = None
             # Get the desired scale and quality of the picture to serve
             upscale_factor, quality = pic_qualities[pic_qual_index]
             scaled_output_size = tuple(int(upscale_factor * i) for i in out_pic_size)

--- a/octoprint_mrbeam/util/__init__.py
+++ b/octoprint_mrbeam/util/__init__.py
@@ -1,16 +1,15 @@
-import sys
-from itertools import chain
-import time
+from collections import Iterable, Mapping
+from copy import copy, deepcopy
+from functools import wraps
+from itertools import chain, repeat, cycle
+import json
 import logging
 import numpy as np
-import json
-from itertools import chain, repeat, cycle
-from functools import wraps
-from copy import copy, deepcopy
+import sys
+import time
 import threading
-from .log import logExceptions, logtime
 
-# from typing import Mapping
+from .log import logExceptions, logtime
 
 
 def dict_merge(d1, d2, leaf_operation=None):  # (d1: dict, d2: dict):
@@ -55,6 +54,29 @@ def dict_map(func, my_dict):
     for k, v, parent in nested_items(__my_dict):
         parent[k] = func(v)
     return __my_dict
+
+
+def dict_get(mapping, path, default=None):
+    """
+    Use a path to get an item from a deep map.
+    ``path`` has to be Iterable.
+    """
+    assert isinstance(mapping, Mapping)
+    assert isinstance(path, Iterable)
+    _mapping = mapping
+    result = None
+    for k in path:
+        if k in _mapping.keys():
+            result = _mapping[k]
+            if isinstance(_mapping[k], Mapping):
+                _mapping = _mapping[k]
+            else:
+                # Otherwise k could be repeated
+                _mapping = {}
+        # path not found in deep map
+        else:
+            return default
+    return result
 
 
 def get_thread(callback=None, logname=None, daemon=False, *th_a, **th_kw):

--- a/tests/rsc/camera_settings/pic_settings_all.yaml
+++ b/tests/rsc/camera_settings/pic_settings_all.yaml
@@ -1,0 +1,42 @@
+hostname_KEY: MrBeam-AXEL
+calibMarkers:
+  NE: [1908, 158]
+  NW: [83, 199]
+  SE: [1885, 1285]
+  SW: [157, 1321]
+cornersFromImage:
+  NE: [1850, 31]
+  NW: [124, 72]
+  SE: [1837, 1347]
+  SW: [206, 1380]
+raw_calibMarkers:
+  NE: [1907, 159]
+  NW: [84, 199]
+  SE: [1885, 1284]
+  SW: [158, 1320]
+raw_cornersFromImage:
+  NE: [1847, 38]
+  NW: [127, 69]
+  SE: [1822, 1346]
+  SW: [203, 1381]
+
+factory_raw_calibMarkers:
+  NE: [1907, 159]
+  NW: [84, 199]
+  SE: [1885, 1284]
+  SW: [158, 1320]
+factory_raw_cornersFromImage:
+  NE: [1847, 38]
+  NW: [127, 69]
+  SE: [1822, 1346]
+  SW: [203, 1381]
+factory_undist_calibMarkers:
+  NE: [1907, 159]
+  NW: [84, 199]
+  SE: [1885, 1284]
+  SW: [158, 1320]
+factory_undist_cornersFromImage:
+  NE: [1847, 38]
+  NW: [127, 69]
+  SE: [1822, 1346]
+  SW: [203, 1381]

--- a/tests/rsc/camera_settings/pic_settings_garbled.yaml
+++ b/tests/rsc/camera_settings/pic_settings_garbled.yaml
@@ -1,0 +1,25 @@
+
+hostname_KEY: MrBeam-AXEL
+calibMarkers:
+  NE: [1908, 158]
+  SW: [157, 1321]
+cornersFromImage:
+  NE: [1850, 31]
+  NW: [124, 72]
+raw_cornersFromImage:
+  NE: [1847, 38]
+  NW: [127, 69]
+  SE: "something"
+  SW: [203, 1381]
+
+factory_raw_cornersFromImage:
+  NE: [1847, 38]
+  NW: [127, 69]
+  SE: [1822, 1346]
+  SW: [203, 1381]
+factory_undist_calibMarkers: null
+factory_undist_cornersFromImage:
+  NE: null
+  NW: null
+  SE: null
+  SW: null

--- a/tests/rsc/camera_settings/pic_settings_raw.yaml
+++ b/tests/rsc/camera_settings/pic_settings_raw.yaml
@@ -1,0 +1,22 @@
+hostname_KEY: MrBeam-AXEL
+raw_calibMarkers:
+  NE: [1907, 159]
+  NW: [84, 199]
+  SE: [1885, 1284]
+  SW: [158, 1320]
+raw_cornersFromImage:
+  NE: [1847, 38]
+  NW: [127, 69]
+  SE: [1822, 1346]
+  SW: [203, 1381]
+
+factory_raw_calibMarkers:
+  NE: [1907, 159]
+  NW: [84, 199]
+  SE: [1885, 1284]
+  SW: [158, 1320]
+factory_raw_cornersFromImage:
+  NE: [1847, 38]
+  NW: [127, 69]
+  SE: [1822, 1346]
+  SW: [203, 1381]

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 import pytest
-import time
 from os.path import dirname, basename, join, split, realpath
 import random
 

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
-import pytest
 from os.path import dirname, basename, join, split, realpath
 import random
+import pytest
 
 from octoprint.settings import settings
 

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+import pytest
+import time
+from os.path import dirname, basename, join, split, realpath
+import random
+
+from octoprint.settings import settings
+
+# ~ Test camera settings, i.e. pic_settings and lens calibrations
+
+from octoprint_mrbeam.camera.config import (
+    calibration_needed_from_file,
+    is_corner_calibration,
+)
+from octoprint_mrbeam.camera.definitions import QD_KEYS
+
+sett = settings()  # fix some init bug
+path = dirname(realpath(__file__))
+CAM_SETTINGS_DIR = join(path, "rsc", "camera_settings")
+
+SETTINGS_ALL = "pic_settings_all.yaml"
+SETTINGS_RAW = "pic_settings_raw.yaml"
+SETTINGS_GARBLED = "pic_settings_garbled.yaml"
+SETTINGS_FACTORY = "pic_settings_factory.yaml"
+
+SETTINGS_HAS_RAW = (SETTINGS_ALL, SETTINGS_RAW)
+# SETTINGS_FACTORY_
+
+
+@pytest.mark.datafiles(
+    join(CAM_SETTINGS_DIR, SETTINGS_ALL),
+    join(CAM_SETTINGS_DIR, SETTINGS_RAW),
+    join(CAM_SETTINGS_DIR, SETTINGS_GARBLED),
+)
+def test_corner_calibration_file(datafiles):
+    # ~ Settings contain the calibration values from the raw pictures are fine.
+    for f_name in SETTINGS_HAS_RAW:
+        settings_path = str(datafiles / f_name)
+        assert not calibration_needed_from_file(settings_path)
+    for f_name in (SETTINGS_GARBLED, "not_a_file_name.yaml"):
+        settings_path = str(datafiles / f_name)
+        assert calibration_needed_from_file(settings_path)
+
+
+def test_is_corner_calibration():
+    def rand_coords():
+        return {q: [random.randint(0, 2000), random.randint(0, 1500)] for q in QD_KEYS}
+
+    conf_map = {
+        "corners": {
+            "factory": {"raw": rand_coords()},
+            "user": {"undistorted": rand_coords()},
+        },
+        "markers": {
+            "factory": {
+                "raw": rand_coords(),
+                "undistorted": rand_coords(),
+            },
+            "user": {"undistorted": rand_coords()},
+        },
+    }
+    assert is_corner_calibration(conf_map, "factory", "raw")
+    assert is_corner_calibration(conf_map, "user", "undistorted")
+    assert not is_corner_calibration(conf_map, "factory", "undistorted")
+    assert not is_corner_calibration(conf_map, "user", "raw")


### PR DESCRIPTION
The logic for determining whether a corner calibration is required was slightly broken. The result was that the users couldn't always do a lens calibration.