### PR TITLE
enabled recover mode of the lxml XMLParser.

### DIFF
--- a/octoprint_mrbeam/gcodegenerator/converter.py
+++ b/octoprint_mrbeam/gcodegenerator/converter.py
@@ -661,7 +661,7 @@ class Converter:
     def parse(self, file=None):
         try:
             stream = open(self.svg_file, "r")
-            p = etree.XMLParser(huge_tree=True)
+            p = etree.XMLParser(huge_tree=True, recover=True)
             self.document = etree.parse(stream, parser=p)
             stream.close()
             self._log.info("parsed %s" % self.svg_file)


### PR DESCRIPTION
[Wichtel_neu.zip](https://github.com/mrbeam/MrBeamPlugin/files/5519391/Wichtel_neu.zip)

backend does not crash anymore on the attached file. 