### PR TITLE
Fix unicode file write with unicode content.

### DIFF
--- a/octoprint_mrbeam/filemanager/__init__.py
+++ b/octoprint_mrbeam/filemanager/__init__.py
@@ -27,9 +27,8 @@ class MrbFileManager(FileManager):
             self.content = content
 
         def save(self, absolute_dest_path):
-            with open(absolute_dest_path, "w") as d:
-                d.write(self.content)
-                d.close()
+            with open(absolute_dest_path, "wb") as d:
+                d.write(self.content.encode("UTF-8"))
 
     def __init__(self, plugin):
         self._plugin = plugin


### PR DESCRIPTION
Fixes #1088

Also a `with open(path) as f` implies closing the file on exit of the `with` statement.