### PR TITLE
Support mode: removed 24hrs check and added onUserLoggedin check

### DIFF
--- a/octoprint_mrbeam/__init__.py
+++ b/octoprint_mrbeam/__init__.py
@@ -68,7 +68,11 @@ from octoprint_mrbeam.software_update_information import (
     SW_UPDATE_TIER_BETA,
     SW_UPDATE_TIER_DEV,
 )
-from octoprint_mrbeam.support import check_support_mode, check_calibration_tool_mode
+from octoprint_mrbeam.support import (
+    check_support_mode,
+    check_calibration_tool_mode,
+    on_user_loggedin,
+)
 from octoprint_mrbeam.util.cmd_exec import exec_cmd, exec_cmd_output
 from octoprint_mrbeam.cli import get_cli_commands
 from .materials import materials
@@ -1965,6 +1969,7 @@ class MrBeamPlugin(
             camera_stop_lens_calibration=[],
             generate_calibration_markers_svg=[],
             cancel_final_extraction=[],
+            on_user_loggedin=["username"],
         )
 
     def on_api_command(self, command, data):
@@ -2079,6 +2084,13 @@ class MrBeamPlugin(
             )  # TODO move this func to other file
         elif command == "cancel_final_extraction":
             self.dust_manager.set_user_abort_final_extraction()
+        elif command == "on_user_loggedin":
+            username = data.get("username", None)
+            self._logger.info(
+                "on_user_loggedin sent by frontend - username: %s", username
+            )
+            # checks if support mode file neesd to be deleted
+            on_user_loggedin(self, username)
 
         return NO_CONTENT
 

--- a/octoprint_mrbeam/static/js/mrbeam.js
+++ b/octoprint_mrbeam/static/js/mrbeam.js
@@ -339,7 +339,7 @@ $(function () {
             }
         };
 
-        self.onUserLoggedIn = function () {
+        self.onUserLoggedIn = function (currentUser) {
             self.removeOpSafeModeOptionFromSystemMenu();
 
             if (!self._ajaxErrorRegistered) {
@@ -354,6 +354,10 @@ $(function () {
                     }
                 });
             }
+
+            OctoPrint.simpleApiCommand("mrbeam", "on_user_loggedin", {
+                username: currentUser.name,
+            });
         };
 
         self.onUserLoggedOut = function () {

--- a/octoprint_mrbeam/support.py
+++ b/octoprint_mrbeam/support.py
@@ -24,8 +24,8 @@ def check_support_mode(plugin):
     try:
         if plugin._settings.get(["dev", "support_mode"]) or (
             os.path.isfile(SUPPORT_STICK_FILE_PATH)
-            and time.time() - os.path.getmtime(SUPPORT_STICK_FILE_PATH)
-            < SUPPORT_STICK_FILE_MAX_AGE
+            # and time.time() - os.path.getmtime(SUPPORT_STICK_FILE_PATH)
+            # < SUPPORT_STICK_FILE_MAX_AGE
         ):
             _logger.info("SUPPORT MODE ENABLED")
             support_mode_enabled = True
@@ -49,8 +49,8 @@ def check_calibration_tool_mode(plugin):
     try:
         if plugin._settings.get(["dev", "calibration_tool_mode"]) or (
             os.path.isfile(CALIBRATION_STICK_FILE_PATH)
-            and time.time() - os.path.getmtime(CALIBRATION_STICK_FILE_PATH)
-            < SUPPORT_STICK_FILE_MAX_AGE
+            # and time.time() - os.path.getmtime(CALIBRATION_STICK_FILE_PATH)
+            # < SUPPORT_STICK_FILE_MAX_AGE
         ):
             _logger.info("CALIBRATION TOOL MODE ENABLED")
             mode_enabled = True
@@ -60,6 +60,33 @@ def check_calibration_tool_mode(plugin):
         _logger.exception("Error while checking calibration tool mode")
 
     return mode_enabled
+
+
+def on_user_loggedin(plugin, username):
+    """
+    Deletes SUPPORT_STICK_FILE_PATH and CALIBRATION_STICK_FILE_PATH if username is not a mr beam email
+    :param plugin: MrBeam Plugin instance
+    :param username: name of the loggedin user
+    """
+    if "@mr-beam.org" not in username:
+        if os.path.isfile(SUPPORT_STICK_FILE_PATH):
+            _logger.warn("Removing support mode file - reason: on_user_loggedin")
+            try:
+                os.remove(SUPPORT_STICK_FILE_PATH)
+            except Exception as e:
+                _logger.warn(
+                    "Exception while removing support mode file on_user_loggedin"
+                )
+        if os.path.isfile(CALIBRATION_STICK_FILE_PATH):
+            _logger.warn(
+                "Removing calibration tool mode file - reason: on_user_loggedin"
+            )
+            try:
+                os.remove(CALIBRATION_STICK_FILE_PATH)
+            except Exception as e:
+                _logger.warn(
+                    "Exception while removing calibration tool mode file on_user_loggedin"
+                )
 
 
 def set_support_user(plugin, support_mode):


### PR DESCRIPTION
removed 24hrs check on support file or calibration tool file because it drove Basti and Marcel nuts:
If there was an ntp time fix, the support file usually appeared older than 24hrs becasue it was created before the time fix happened.