### PR TITLE
fixes #1104 (Unproportional scaling of x and y axis)

### DIFF
--- a/octoprint_mrbeam/static/js/working_area.js
+++ b/octoprint_mrbeam/static/js/working_area.js
@@ -2265,11 +2265,12 @@ $(function () {
 
                     var fx = width / widthVBox;
                     var fy = height / heightVBox;
+                    const finalF = Math.min(fx, fy);
                     var dx = offsetVBoxX * fx;
                     var dy = offsetVBoxY * fy;
                     return [
-                        [fx, 0, 0],
-                        [0, fy, 0],
+                        [finalF, 0, 0],
+                        [0, finalF, 0],
                         [dx, dy, 1],
                     ];
                 }


### PR DESCRIPTION
if document width / height and viewbox width / height have different x and y scales, the smaller unit is chosen. 
Found out by trying...