### PR TITLE
Fix multiselect on Mac: support for metaKey (command)

### DIFF
--- a/octoprint_mrbeam/static/js/mother_viewmodel.js
+++ b/octoprint_mrbeam/static/js/mother_viewmodel.js
@@ -29,6 +29,9 @@ $(function () {
         self.serverPrintTime = 0;
         self.printTimeInterval = null;
 
+        // ctrl or mac command key (https://stackoverflow.com/a/3922353/2631798)
+        self.KEY_CODES_CTRL_COMMAND = [17, 91, 93, 224];
+
         // MrBeam Logo click activates workingarea tab
         $("#mrbeam_logo_link").click(function () {
             $("#wa_tab_btn").tab("show");
@@ -195,13 +198,14 @@ $(function () {
 
             self.addClassesForModifierKeys = function (event) {
                 if (event.which === 16) document.body.classList.add("shiftKey");
-                if (event.which === 17) document.body.classList.add("ctrlKey");
+                if (self.KEY_CODES_CTRL_COMMAND.includes(event.which))
+                    document.body.classList.add("ctrlKey");
                 if (event.which === 18) document.body.classList.add("altKey");
             };
             self.removeClassesForModifierKeys = function (event) {
                 if (event.which === 16)
                     document.body.classList.remove("shiftKey");
-                if (event.which === 17)
+                if (self.KEY_CODES_CTRL_COMMAND.includes(event.which))
                     document.body.classList.remove("ctrlKey");
                 if (event.which === 18)
                     document.body.classList.remove("altKey");

--- a/octoprint_mrbeam/static/js/snap_transform_plugin.js
+++ b/octoprint_mrbeam/static/js/snap_transform_plugin.js
@@ -40,7 +40,8 @@
             elem.add_fill();
             elem.unclick(); // avoid multiple click actions
             elem.click(function (event, i) {
-                if (event.ctrlKey) {
+                // ctrlKey for PC, metaKey for Mac command key
+                if (event.ctrlKey || event.metaKey) {
                     elem.paper.mbtransform.toggleElement(elem);
                 } else {
                     elem.paper.mbtransform.activate(elem);
@@ -222,7 +223,8 @@
 
         self.translateStart = function (target, x, y, event) {
             // x, y, dx, dy pixel coordinates according to <svg width="..." height="..." >
-            if (event.ctrlKey) {
+            // ctrlKey for PC, metaKey for Mac command key
+            if (event.ctrlKey || event.metaKey) {
                 console.info(
                     "translateStart with ShiftKey down: Should bubble event to target inside. Not supported right now."
                 );
@@ -944,7 +946,6 @@
         self.toggle = function (elements_to_transform) {
             if (self.transformHandleGroup.node.classList.contains("active")) {
                 self.deactivate();
-                return;
             } else {
                 self.activate(elements_to_transform);
             }

--- a/octoprint_mrbeam/static/js/working_area.js
+++ b/octoprint_mrbeam/static/js/working_area.js
@@ -2167,7 +2167,6 @@ $(function () {
                     self.removeSVG(fileObj);
                 }
             }
-            return;
         };
 
         self._getFileObjectForSvg = function (svg) {
@@ -2563,7 +2562,6 @@ $(function () {
 </svg>`;
                 return svg;
             } else {
-                return;
             }
         };
 
@@ -3895,14 +3893,18 @@ $(function () {
         // ***********************************************************
 
         // general modification keys
+        // TODO: this does not seem to be used anywhere. Remove?
         self.wa_key_down = function (target, ev) {
             console.log("Keydown", target, ev);
-            if (ev.originalEvent.ctrlKey) {
+            // ctrlKey for PC, metaKey for Mac command key
+            if (ev.originalEvent.ctrlKey || ev.originalEvent.metaKey) {
                 target.classList.add("ctrl");
             }
         };
+        // TODO: this does not seem to be used anywhere. Remove?
         self.wa_key_up = function (target, ev) {
-            if (ev.originalEvent.ctrlKey) {
+            // ctrlKey for PC, metaKey for Mac command key
+            if (ev.originalEvent.ctrlKey || ev.originalEvent.metaKey) {
                 target.classList.remove("ctrl");
             }
         };


### PR DESCRIPTION
Multiselect was not working on Mac since ctrl-key + click triggers context menu to open.
Mac user want to use command + click anyway. 
Now it's working. Also added command key support in other places as well.