### PR TITLE
Fix: utf-8 encoding for stings coming from frontend console

### DIFF
--- a/octoprint_mrbeam/__init__.py
+++ b/octoprint_mrbeam/__init__.py
@@ -2021,8 +2021,11 @@ class MrBeamPlugin(
     def console_log(self):
         try:
             data = request.json
-            event = data.get("event")
+            event = data.get("event").encode("utf-8")
             payload = data.get("payload", dict())
+            for key in payload.keys():
+                if isinstance(payload[key], basestring):
+                    payload[key] = payload[key].encode("utf-8")
             func = payload.get("function", None)
             f_level = payload.get("level", None)
             stack = None
@@ -2042,6 +2045,8 @@ class MrBeamPlugin(
             except:
                 pass
             msg = payload.get("msg", "")
+            msg = msg[:1000] + "..." if len(msg) > 1000 else msg
+
             if func and func is not "null":
                 msg = "{} ({})".format(msg, func)
             self._frontend_logger.log(
@@ -2070,8 +2075,11 @@ class MrBeamPlugin(
     def analytics_data(self):
         try:
             data = request.json
-            event = data.get("event")
+            event = data.get("event").encode("utf-8")
             payload = data.get("payload", dict())
+            for key in payload.keys():
+                if isinstance(payload[key], basestring):
+                    payload[key] = payload[key].encode("utf-8")
             self.analytics_handler.add_frontend_event(event, payload)
 
         except Exception as e:


### PR DESCRIPTION
Fixes this exception and add some more protection:
```
2021-02-26 13:26:37,724 - octoprint.plugins.mrbeam - ERROR - Could not process frontend console_log: 'ascii' codec can't encode character u'\u201c' in position 101: ordinal not in range(128) - Data = {u'event': u'console', u'payload': {u'function': u'Object.<anonymous>', u'stacktrace': [u'at Object.<anonymous> (http://mrbeam-andy.local/plugin/mrbeam/static/js/messages.js:63:29)', u'at fire (http://mrbeam-andy.local/static/js/lib/jquery/jquery.js:3187:31)', u'at Object.fireWith [as resolveWith] (http://mrbeam-andy.local/static/js/lib/jquery/jquery.js:3317:7)', u'at done (http://mrbeam-andy.local/static/js/lib/jquery/jquery.js:8757:14)', u'at XMLHttpRequest.<anonymous> (http://mrbeam-andy.local/static/js/lib/jquery/jquery.js:9123:9)'], u'level': u'log', u'browser_time': u'26/02/2021, 14:26:36', u'ts': 1614345996937L, u'file': u'/plugin/mrbeam/static/js/messages.js', u'msg': u'Saved Remote Messages loaded:  {"messages":{"0":{"content":{"de":{"body":"Mit unserer neuen Funktion \u201cNachrichten von Mr Beam\u201d bleibst du immer auf dem Laufenden rund um deinen Mr Beam Lasercutter.\\nMehr dazu in K\xfcrze.\\nBitte stelle sicher, dass du und dein Mr Beam Lasercutter mit dem Internet verbunden sind, um die neuesten Nachrichten zu bekommen.\\n\\nDein Mr Beam Team","title":"Willkommen bei \u201cNachrichten von Mr Beam\u201d"},"en":{"body":"With our new feature \u201cMessages Form Mr Beam\u201d you always be kept up to date with the latest news from Mr Beam about your lasercutter.\\nMore to come here shortly.\\nPlease make sure you and your Mr Beam lasercutter are connected to the internet to get the latest messages.\\n\\nYour Mr Beam team","title":"Introducing \u201cMessages Form Mr Beam\u201d"}},"date":"12. 2. 2021","id":1,"notification":{"de":{"body":"Bleibe auf dem Laufenden mit Nachrichten von Mr Beam","title":"Willkommen bei \u201cNachrichten von Mr Beam\u201d"},"en":{"body":"Stay up to date with the latest news from Mr Beam","title":"Introducing \u201cMessages Form Mr Beam\u201d"},"sticky":30,"type":"info"},"restrictions":{"__":"Evaluation  of restrictions needs to be true to show the message","channels":[],"not_first_run":false,"ts_after":0,"ts_before":0,"version":[],"version_and_newer":null,"version_and_older":null}}},"put":0}', u'line': u'63', u'col': u'29'}}
Traceback (most recent call last):
  File "/home/pi/oprint/local/lib/python2.7/site-packages/octoprint_mrbeam/__init__.py", line 2046, in console_log
    msg = "{} ({})".format(msg, func)
UnicodeEncodeError: 'ascii' codec can't encode character u'\u201c' in position 101: ordinal not in range(128)
```