### PR TITLE
Removed link to old forum

### DIFF
--- a/octoprint_mrbeam/templates/settings/about_settings.jinja2
+++ b/octoprint_mrbeam/templates/settings/about_settings.jinja2
@@ -89,7 +89,6 @@
                     </div>
 
                     <div><strong>{{ _('Online Support Portal') }}:</strong> <a href="https://www.mr-beam.org/support" target="_blank">mr-beam.org/support</a></div>
-                    <div><strong>{{ _('Community Forum') }}:</strong> <a href="https://www.mr-beam.org/forum" target="_blank">mr-beam.org/forum</a></div>
                     <div><strong>{{ _('Privacy Policies') }}:</strong>
                         <a href="http://shop.mr-beam.org/privacy" target="_blank">{{ _('Mr Beam Web Site') }}</a> |
                         <a href="/plugin/findmymrbeam/static/docs/findmrbeamorg_privacy_policy.pdf" target="_blank">{{ _('find.mr-beam service') }}</a> |


### PR DESCRIPTION
This is how it looked before:
<img width="646" alt="Bildschirmfoto 2021-03-03 um 16 09 03" src="https://user-images.githubusercontent.com/4582388/109854576-7f058800-7c57-11eb-8f17-c8e4f61c3b7b.png">
