### PR TITLE
fixes #1192 - Number input fields for design size change if a point number is entered with a comma.

### DIFF
--- a/octoprint_mrbeam/static/js/helpers/working_area_helper.js
+++ b/octoprint_mrbeam/static/js/helpers/working_area_helper.js
@@ -234,6 +234,10 @@ class WorkingAreaHelper {
         return fragment.node.querySelectorAll("svg > *").length <= 0;
     }
 
+    static parseFloatTolerant(str) {
+        return parseFloat(str.replace(",", "."));
+    }
+
     /**
      * Parses two number values (float or int) from given string.
      * Tries to accept any comma and any delimiter between the two numbers
@@ -250,8 +254,8 @@ class WorkingAreaHelper {
                 myString.match(/^(-?\d+)[^0-9-]*(-?\d+)$/) ||
                 myString.match(/(-?\d+[.,]?\d*)[^0-9-]*(-?\d+[.,]?\d*)/);
             if (m) {
-                let x = parseFloat(m[1]);
-                let y = parseFloat(m[2]);
+                let x = WorkingAreaHelper.parseFloatTolerant(m[1]);
+                let y = WorkingAreaHelper.parseFloatTolerant(m[2]);
                 if (!isNaN(x) && !isNaN(y)) {
                     res = [x, y];
                 }
@@ -302,7 +306,7 @@ class WorkingAreaHelper {
                 val = val * options.shift;
             }
             if (options.delimiter === null) {
-                const newVal = parseFloat(event.target.value) + val;
+                const newVal = parseFloatTolerant(event.target.value) + val;
                 event.target.value = `${newVal.toFixed(options.digits)} ${
                     options.unit
                 }`;
@@ -311,14 +315,14 @@ class WorkingAreaHelper {
                 const idxDelimiter = v.search(new RegExp(options.delimiter));
                 if (selStart <= idxDelimiter) {
                     const v1 = v.substring(0, idxDelimiter);
-                    const newV1 = parseFloat(v1) + val;
+                    const newV1 = parseFloatTolerant(v1) + val;
                     event.target.value = `${newV1.toFixed(
                         options.digits
                     )}${v.substring(idxDelimiter)}`;
                 } else {
                     const d = idxDelimiter + options.delimiter.length;
                     const v2 = v.substring(d);
-                    const newV2 = parseFloat(v2) + val;
+                    const newV2 = parseFloatTolerant(v2) + val;
                     event.target.value = `${v.substring(0, d)}${newV2.toFixed(
                         options.digits
                     )}`;

--- a/octoprint_mrbeam/static/js/working_area.js
+++ b/octoprint_mrbeam/static/js/working_area.js
@@ -1585,7 +1585,9 @@ $(function () {
             ) {
                 self.abortFreeTransforms();
                 var svg = snap.select("#" + data.previewId);
-                var newRotate = parseFloat(event.target.value);
+                var newRotate = WorkingAreaHelper.parseFloatTolerant(
+                    event.target.value
+                );
                 const oldRotation = svg.transform().localMatrix.split().rotate;
                 snap.mbtransform.manualTransform(svg, {
                     angle: newRotate - oldRotation,
@@ -1617,7 +1619,9 @@ $(function () {
                     "scale_proportional"
                 );
                 const isMirrored = $(`#${data.id}`).hasClass("isMirrored");
-                const value = parseFloat(event.target.value);
+                const value = WorkingAreaHelper.parseFloatTolerant(
+                    event.target.value
+                );
                 const lm = svg.transform().localMatrix;
                 const currentSx = Math.sqrt(lm.a * lm.a + lm.b * lm.b); // rotation independent scalex factor
                 const currentWidth = svg.getBBox().width;
@@ -1659,7 +1663,9 @@ $(function () {
                 const isProp = $(`#${data.id} .file_list_entry`).hasClass(
                     "scale_proportional"
                 );
-                const value = parseFloat(event.target.value);
+                const value = WorkingAreaHelper.parseFloatTolerant(
+                    event.target.value
+                );
                 const lm = svg.transform().localMatrix;
                 const currentSy = Math.sqrt(lm.c * lm.c + lm.d * lm.d); // rotation independent scaley factor
                 const currentHeight = svg.getBBox().height;


### PR DESCRIPTION
done with a more tolerant method WorkingAreaHelper.parseFloat()