### PR TITLE
Allow for whitespace in /etc/mrbeam.

### DIFF
--- a/octoprint_mrbeam/util/device_info.py
+++ b/octoprint_mrbeam/util/device_info.py
@@ -58,11 +58,11 @@ class DeviceInfo(object):
 
     def _read_file(self):
         try:
+            # See configparser for a better solution
             res = dict()
             with open(self.DEVICE_INFO_FILE, "r") as f:
                 for line in f:
-                    line = line.strip()
-                    token = line.split("=")
+                    token = map(str.strip, line.split("="))
                     if len(token) >= 2:
                         res[token[0]] = token[1]
             return res

--- a/octoprint_mrbeam/util/device_info.py
+++ b/octoprint_mrbeam/util/device_info.py
@@ -62,7 +62,7 @@ class DeviceInfo(object):
             res = dict()
             with open(self.DEVICE_INFO_FILE, "r") as f:
                 for line in f:
-                    token = map(str.strip, line.split("="))
+                    token = list(map(str.strip, line.split("=")))
                     if len(token) >= 2:
                         res[token[0]] = token[1]
             return res


### PR DESCRIPTION
Eventually we should probably use [configparser](https://docs.python.org/3/library/configparser.html)