### PR TITLE
Fix condition to log FrontEnd event [1]

### DIFF
--- a/octoprint_mrbeam/static/js/analytics.js
+++ b/octoprint_mrbeam/static/js/analytics.js
@@ -70,7 +70,7 @@ $(function () {
         });
 
         self.send_fontend_event = function (event, payload) {
-            if (self.isStartupComplete && !self.analyticsEnabled()) {
+            if (!self.isStartupComplete || !self.analyticsEnabled()) {
                 return {};
             }
 


### PR DESCRIPTION
The only reason why this wasn't a problem was because `analyticsEnabled` does not change before startup completes anyway.