### PR TITLE
SW-256 fixed saving mrbeamplugin version number to config

### DIFF
--- a/octoprint_mrbeam/migrate.py
+++ b/octoprint_mrbeam/migrate.py
@@ -294,8 +294,11 @@ class Migration(object):
         return LooseVersion(lower_vers) < LooseVersion(higher_vers)
 
     def save_current_version(self):
-        self.plugin._settings.set(["version"], self.version_current, force=False)
-        self.plugin._settings.save()
+        if self.plugin._settings.get(["version"]) != self.version_current:
+            self.plugin._settings.set(
+                ["version"], self.version_current, force=True
+            )  # force needed to save it if it wasn't there
+            self.plugin._settings.save()
 
     ##########################################################
     #####              general stuff                     #####


### PR DESCRIPTION
reenable the `force` option for setting the version number of the mrbeamplugin to the octoprint config file
so it will write the version to the config event if it wasn't there before 