### PR TITLE
Report broken i2c status in front-end

### DIFF
--- a/octoprint_mrbeam/iobeam/hw_malfunction_handler.py
+++ b/octoprint_mrbeam/iobeam/hw_malfunction_handler.py
@@ -91,7 +91,16 @@ class HwMalfunctionHandler(object):
         )
 
         for malfunction_id, data in messages_sorted:
-            if malfunction_id == self.MALFUNCTION_ID_BOTTOM_OPEN:
+            if malfunction_id == "i2c_bus_malfunction":
+                notifications.append(
+                    self._user_notification_system.get_notification(
+                        notification_id=malfunction_id,
+                        err_msg=data.get("msg", None),
+                        replay=True,
+                    )
+                )
+
+            elif malfunction_id == self.MALFUNCTION_ID_BOTTOM_OPEN:
                 notifications.append(
                     self._user_notification_system.get_notification(
                         notification_id="err_bottom_open", replay=True
@@ -117,7 +126,8 @@ class HwMalfunctionHandler(object):
                 )
             )
 
-        self._user_notification_system.show_notifications(notifications)
+        # Only send a single error message at a time
+        self._user_notification_system.show_notifications(notifications[0])
 
     def get_messages_to_show(self):
         return self._messages_to_show

--- a/octoprint_mrbeam/printing/acc_line_buffer.py
+++ b/octoprint_mrbeam/printing/acc_line_buffer.py
@@ -93,18 +93,6 @@ class AccLineBuffer(object):
         self._lock.writer_release()
         return self._last_responded
 
-    def get_first_item(self):
-        """
-        Returns the first (oldest) item. This is the one to be removed next.
-        :return: item dict(cmd="", i=1, f=23) or None if empty
-        """
-        if self.is_empty():
-            return None
-        self._lock.reader_acquire()
-        res = self.buffer_cmds[0]
-        self._lock.reader_release()
-        return res
-
     def get_last_responded(self):
         """
         returns the last acknowledged command

--- a/octoprint_mrbeam/static/js/user_notification_viewmodel.js
+++ b/octoprint_mrbeam/static/js/user_notification_viewmodel.js
@@ -7,6 +7,18 @@ $(function () {
          * Add notification tempaltes here
          */
         self._notification_templates = {
+            i2c_bus_malfunction: {
+                title: gettext("I2C bus shorted"),
+                text: gettext(
+                    "This is pretty bad. We have detected that the communication bus to different components on the MrBeam is either temporarily or permanently damaged. Please make sure that your laser head is properly connected and restart your Mr Beam. If you see this message agin, please contact our support team."
+                ),
+                type: "error",
+                hide: false,
+                knowledgebase: {
+                    url:
+                        "https://support.mr-beam.org/support/solutions/articles/43000557281-system-messages#lhnotfound",
+                },
+            },
             err_leaserheadunit_missing: {
                 title: gettext("No laser head unit found"),
                 text: gettext(


### PR DESCRIPTION
Major:

- Add a new Error message in the front end: i2c broken
- Only show 1 error at a time - the one with highest priority
- Fan handler does not time out as long as some data comes regularly

Refactor:

- docstrings
- var = foo[bar] => foo.get(bar, var) # when bar is not a mandatory key
- Add comments in some obscure code places
- foo == False => not foo
- magic number => constant
- mutate constant => copy constant as private var
- Simplify Threads (un-nesting)
- except: => except Exception: (does not catch SIGTERM)
- Remove superflous try / except
- logger.error(my_exception) => logger.exception(my_exception)
- def foo(): pass => foo = do_nothing_func
  - saves lines
  - highlights that foo() is not important
- complex if / elif key in foo: bar(foo[key]) => use lookup map
  - better readability
  - saves a bunch of lines (see _handle_fan_dynamic)
- foo.get("bar", None) == "barbar" => foo.get("bar") == "barbar"
- Repeated foo[bar] => var = foo[bar]
- Avoid basic classes as var names (str)
- Remove unused functions

Minor :

- Handles partial fan dynamic datasets as an update (refresh) for the dynamic dataset

Known bug: If iobeam reports partial operational data (new default), the laser temperature gets "out of date" and stops the laser job