### PR TITLE
Do not handle unicode exception if not needed.

### DIFF
--- a/octoprint_mrbeam/mrb_logger.py
+++ b/octoprint_mrbeam/mrb_logger.py
@@ -84,11 +84,9 @@ class MrbLogger(object):
         :type kwargs:
         """
 
-        try:
+        import io
+        if isinstance(msg, (str, io.IOBase)):
             msg = unicode(msg, "utf-8")
-        except TypeError:
-            # If it's already unicode we get this TypeError
-            pass
         if kwargs.pop("terminal", True if level >= logging.WARN else False):
             self._terminal(level, msg, *args, **kwargs)
         if kwargs.pop("terminal_as_comm", False) or level == self.LEVEL_COMM:


### PR DESCRIPTION
In the log function, the TypeError that is removed here will
take precedent over an other potential Exception being logged. - Thereby
we only manage to log the error message, not the stacktrace.

The proposed solution handles the unicode conversion for instances that
we know can be converted.