### PR TITLE
bugfix/SW-890 svg embedded images are misaligned

### DIFF
--- a/octoprint_mrbeam/static/js/matrix_oven.js
+++ b/octoprint_mrbeam/static/js/matrix_oven.js
@@ -148,35 +148,47 @@ Snap.plugin(function (Snap, Element, Paper, global) {
                 y = 0;
             }
             var transform = elem.transform();
-            var matrix = transform["totalMatrix"].add(correctionMatrix);
-            var transformedX = matrix.x(x, y);
-            var transformedY = matrix.y(x, y);
-            var transformedW = matrix.x(x + w, y + h) - transformedX;
-            var transformedH = matrix.y(x + w, y + h) - transformedY;
+            const tm = transform["totalMatrix"].add(correctionMatrix);
+            const lm = transform["localMatrix"];
 
-            // keep mirroring in the elements matrix if mirrored
-            const mirroredX = matrix.a < 0;
-            const mirroredY = matrix.d < 0;
-            let mat = Snap.matrix();
-            if (mirroredX) {
-                // mirrored x-axis
-                transformedW = Math.abs(transformedW);
-                mat.a = -1;
-                transformedX = -transformedX;
-            }
-            if (mirroredY) {
-                // mirrored x-axis
-                transformedH = Math.abs(transformedH);
-                mat.d = -1;
-                transformedY = -transformedY;
-            }
-            elem.attr({
-                x: transformedX,
-                y: transformedY,
-                width: transformedW,
-                height: transformedH,
-            });
-            elem.transform(mat);
+            elem.transform(tm);
+            //            tm.add(lm.invert());
+
+            // keep local matrix
+            // apply matrices from parent element as those are removed
+
+            //            var transformedX = matrix.x(x, y);
+            //            var transformedY = matrix.y(x, y);
+            //            var transformedW = matrix.x(x + w, y + h) - transformedX;
+            //            var transformedH = matrix.y(x + w, y + h) - transformedY;
+
+            //            const transformComponents = matrix.split();
+            //            const transformedW = w * transformComponents.scalex;
+            //            const transformedH = h * transformComponents.scaley;
+            //
+            //            // keep mirroring in the elements matrix if mirrored
+            //            const mirroredX = matrix.a < 0;
+            //            const mirroredY = matrix.d < 0;
+            //            let mat = Snap.matrix();
+            //            if (mirroredX) {
+            //                // mirrored x-axis
+            //                transformedW = Math.abs(transformedW);
+            //                mat.a = -1;
+            //                transformedX = -transformedX;
+            //            }
+            //            if (mirroredY) {
+            //                // mirrored x-axis
+            //                transformedH = Math.abs(transformedH);
+            //                mat.d = -1;
+            //                transformedY = -transformedY;
+            //            }
+            //            elem.attr({
+            //                x: transformedX,
+            //                y: transformedY,
+            //                width: transformedW,
+            //                height: transformedH,
+            //            });
+            //            elem.transform(mat);
             return ignoredElements;
         }
 

--- a/octoprint_mrbeam/static/js/matrix_oven.js
+++ b/octoprint_mrbeam/static/js/matrix_oven.js
@@ -132,63 +132,10 @@ Snap.plugin(function (Snap, Element, Paper, global) {
         }
 
         if (elem.type === "image") {
-            var x = parseFloat(elem.attr("x")),
-                y = parseFloat(elem.attr("y")),
-                w = parseFloat(elem.attr("width")),
-                h = parseFloat(elem.attr("height"));
-
-            // Validity checks from http://www.w3.org/TR/SVG/shapes.html#RectElement:
-            // If 'x' and 'y' are not specified, then set both to default=0. // CorelDraw is creating that sometimes
-            if (!isFinite(x)) {
-                console.log("Image: No x value -> using 0 (SVG default)");
-                x = 0;
-            }
-            if (!isFinite(y)) {
-                console.log("Image: No y value -> using 0 (SVG default)");
-                y = 0;
-            }
+            // just apply total transform matrix which incorporates transforms of parent elements as well.
             var transform = elem.transform();
             const tm = transform["totalMatrix"].add(correctionMatrix);
-            const lm = transform["localMatrix"];
-
             elem.transform(tm);
-            //            tm.add(lm.invert());
-
-            // keep local matrix
-            // apply matrices from parent element as those are removed
-
-            //            var transformedX = matrix.x(x, y);
-            //            var transformedY = matrix.y(x, y);
-            //            var transformedW = matrix.x(x + w, y + h) - transformedX;
-            //            var transformedH = matrix.y(x + w, y + h) - transformedY;
-
-            //            const transformComponents = matrix.split();
-            //            const transformedW = w * transformComponents.scalex;
-            //            const transformedH = h * transformComponents.scaley;
-            //
-            //            // keep mirroring in the elements matrix if mirrored
-            //            const mirroredX = matrix.a < 0;
-            //            const mirroredY = matrix.d < 0;
-            //            let mat = Snap.matrix();
-            //            if (mirroredX) {
-            //                // mirrored x-axis
-            //                transformedW = Math.abs(transformedW);
-            //                mat.a = -1;
-            //                transformedX = -transformedX;
-            //            }
-            //            if (mirroredY) {
-            //                // mirrored x-axis
-            //                transformedH = Math.abs(transformedH);
-            //                mat.d = -1;
-            //                transformedY = -transformedY;
-            //            }
-            //            elem.attr({
-            //                x: transformedX,
-            //                y: transformedY,
-            //                width: transformedW,
-            //                height: transformedH,
-            //            });
-            //            elem.transform(mat);
             return ignoredElements;
         }
 

--- a/octoprint_mrbeam/static/js/render_fills.js
+++ b/octoprint_mrbeam/static/js/render_fills.js
@@ -127,10 +127,15 @@ Snap.plugin(function (Snap, Element, Paper, global) {
             let rasterEl = marked[i];
             let bbox;
             try {
-              bbox = rasterEl.get_total_bbox();
-            }
-            catch(error) {
-                console.warn(`Getting bounding box for ${rasterEl} failed.`, error);
+                bbox = rasterEl.get_total_bbox();
+                //              if(MRBEAM_DEBUG_RENDERING){ // enable to debug render bbox
+                //                  const debugBB = svg.paper.rect(bbox).attr({fill: 'none', stroke:"#FF00FF", "stroke-dasharray": "1 1 1 1", class:"debugBBox"});
+                //              }
+            } catch (error) {
+                console.warn(
+                    `Getting bounding box for ${rasterEl} failed.`,
+                    error
+                );
                 continue;
             }
             // find overlaps
@@ -172,13 +177,20 @@ Snap.plugin(function (Snap, Element, Paper, global) {
                 rasterEl.addClass(`rasterCluster${c}`)
             );
             let tmpSvg = svg.clone();
-            tmpSvg.selectAll(`.toRaster:not(.rasterCluster${c})`).forEach((element) => {
-                let elementToBeRemoved = tmpSvg.select('#' + element.attr('id'));
-                let elementsToBeExcluded = ["text", "tspan"]
-                if (elementToBeRemoved && !elementsToBeExcluded.includes(elementToBeRemoved.type)) {
-                    elementToBeRemoved.remove();
-                }
-            });
+            tmpSvg
+                .selectAll(`.toRaster:not(.rasterCluster${c})`)
+                .forEach((element) => {
+                    let elementToBeRemoved = tmpSvg.select(
+                        "#" + element.attr("id")
+                    );
+                    let elementsToBeExcluded = ["text", "tspan"];
+                    if (
+                        elementToBeRemoved &&
+                        !elementsToBeExcluded.includes(elementToBeRemoved.type)
+                    ) {
+                        elementToBeRemoved.remove();
+                    }
+                });
             // Fix IDs of filter references, those are not cloned correct (probably because reference is in style="..." definition)
             tmpSvg.fixIds("defs filter[mb\\:id]", "mb:id"); // namespace attribute selectors syntax: [ns\\:attrname]
             // DON'T fix IDs of textPath references, they're cloned correct.

--- a/octoprint_mrbeam/static/js/snap_helpers.js
+++ b/octoprint_mrbeam/static/js/snap_helpers.js
@@ -63,7 +63,7 @@ Snap.plugin(function (Snap, Element, Paper, global) {
     Element.prototype.get_total_bbox = function () {
         const el = this;
         const mat = el.transform().totalMatrix;
-        const bb = el.getBBox();
+        const bb = el.getBBox(true); // isWithoutTransform=true
         return Snap.path.getBBoxWithTransformation(bb, mat);
     };
 });


### PR DESCRIPTION
Way simpler solution than before: just apply total transform matrix instead of modifying attributes x, y, width, height. 
Attribute modification is not able to reflect rotation and mirroring at all. Therefore there is no way to remove the transform completely. Finally it does not make sense to reduce it to mirroring or rotation only. 
