### PR TITLE
SW-1060 SVGs files saved as Inkscape SVG do not work anymore after update. When saved as normal svg it worked again

### DIFF
--- a/octoprint_mrbeam/static/js/helpers/working_area_helper.js
+++ b/octoprint_mrbeam/static/js/helpers/working_area_helper.js
@@ -1,4 +1,48 @@
 class WorkingAreaHelper {
+    static versionCompare(v1, v2, options) {
+        var lexicographical = options && options.lexicographical,
+            zeroExtend = options && options.zeroExtend,
+            v1parts = v1.split("."),
+            v2parts = v2.split(".");
+
+        function isValidPart(x) {
+            return (lexicographical ? /^\d+[A-Za-z]*$/ : /^\d+$/).test(x);
+        }
+
+        if (!v1parts.every(isValidPart) || !v2parts.every(isValidPart)) {
+            return NaN;
+        }
+
+        if (zeroExtend) {
+            while (v1parts.length < v2parts.length) v1parts.push("0");
+            while (v2parts.length < v1parts.length) v2parts.push("0");
+        }
+
+        if (!lexicographical) {
+            v1parts = v1parts.map(Number);
+            v2parts = v2parts.map(Number);
+        }
+
+        for (var i = 0; i < v1parts.length; ++i) {
+            if (v2parts.length === i) {
+                return 1;
+            }
+
+            if (v1parts[i] === v2parts[i]) {
+            } else if (v1parts[i] > v2parts[i]) {
+                return 1;
+            } else {
+                return -1;
+            }
+        }
+
+        if (v1parts.length !== v2parts.length) {
+            return -1;
+        }
+
+        return 0;
+    }
+
     static getHumanReadableId(length) {
         length = length || 4;
         let out = [];

--- a/octoprint_mrbeam/static/js/working_area.js
+++ b/octoprint_mrbeam/static/js/working_area.js
@@ -1158,7 +1158,7 @@ $(function () {
             if (declaredUnit === "px" || declaredUnit === "") {
                 if (generator.generator === "inkscape") {
                     if (
-                        window.compareVersions(
+                        WorkingAreaHelper.versionCompare(
                             generator.version,
                             "0.91"
                         ) <= 0


### PR DESCRIPTION
- Inkscape version embedded in SVGs are not Semantic and thus are incompatible with the semver library