### PR TITLE
SW-1060 Inkscape version in SVG is incompatible with semver comparison library

### DIFF
--- a/octoprint_mrbeam/static/js/helpers/working_area_helper.js
+++ b/octoprint_mrbeam/static/js/helpers/working_area_helper.js
@@ -1,48 +1,4 @@
 class WorkingAreaHelper {
-    static versionCompare(v1, v2, options) {
-        var lexicographical = options && options.lexicographical,
-            zeroExtend = options && options.zeroExtend,
-            v1parts = v1.split("."),
-            v2parts = v2.split(".");
-
-        function isValidPart(x) {
-            return (lexicographical ? /^\d+[A-Za-z]*$/ : /^\d+$/).test(x);
-        }
-
-        if (!v1parts.every(isValidPart) || !v2parts.every(isValidPart)) {
-            return NaN;
-        }
-
-        if (zeroExtend) {
-            while (v1parts.length < v2parts.length) v1parts.push("0");
-            while (v2parts.length < v1parts.length) v2parts.push("0");
-        }
-
-        if (!lexicographical) {
-            v1parts = v1parts.map(Number);
-            v2parts = v2parts.map(Number);
-        }
-
-        for (var i = 0; i < v1parts.length; ++i) {
-            if (v2parts.length === i) {
-                return 1;
-            }
-
-            if (v1parts[i] === v2parts[i]) {
-            } else if (v1parts[i] > v2parts[i]) {
-                return 1;
-            } else {
-                return -1;
-            }
-        }
-
-        if (v1parts.length !== v2parts.length) {
-            return -1;
-        }
-
-        return 0;
-    }
-
     static getHumanReadableId(length) {
         length = length || 4;
         let out = [];

--- a/octoprint_mrbeam/static/js/helpers/working_area_helper.js
+++ b/octoprint_mrbeam/static/js/helpers/working_area_helper.js
@@ -1,4 +1,48 @@
 class WorkingAreaHelper {
+    static versionCompare(v1, v2, options) {
+        var lexicographical = options && options.lexicographical,
+            zeroExtend = options && options.zeroExtend,
+            v1parts = v1.split("."),
+            v2parts = v2.split(".");
+
+        function isValidPart(x) {
+            return (lexicographical ? /^\d+[A-Za-z]*$/ : /^\d+$/).test(x);
+        }
+
+        if (!v1parts.every(isValidPart) || !v2parts.every(isValidPart)) {
+            return NaN;
+        }
+
+        if (zeroExtend) {
+            while (v1parts.length < v2parts.length) v1parts.push("0");
+            while (v2parts.length < v1parts.length) v2parts.push("0");
+        }
+
+        if (!lexicographical) {
+            v1parts = v1parts.map(Number);
+            v2parts = v2parts.map(Number);
+        }
+
+        for (var i = 0; i < v1parts.length; ++i) {
+            if (v2parts.length === i) {
+                return 1;
+            }
+
+            if (v1parts[i] === v2parts[i]) {
+            } else if (v1parts[i] > v2parts[i]) {
+                return 1;
+            } else {
+                return -1;
+            }
+        }
+
+        if (v1parts.length !== v2parts.length) {
+            return -1;
+        }
+
+        return 0;
+    }
+
     static getHumanReadableId(length) {
         length = length || 4;
         let out = [];

--- a/octoprint_mrbeam/static/js/working_area.js
+++ b/octoprint_mrbeam/static/js/working_area.js
@@ -1157,12 +1157,26 @@ $(function () {
             }
             if (declaredUnit === "px" || declaredUnit === "") {
                 if (generator.generator === "inkscape") {
-                    if (
-                        window.compareVersions(
-                            generator.version,
+                    let isOldInkscapeVersion = NaN;
+                    try {
+                        isOldInkscapeVersion= window.compareVersions(
+                            // 1.1.2 (1:1.1+202202050950+0a00cf5339) -> 1.1
+                            generator.version.split('.').slice(0,2).join('.'),
                             "0.91"
-                        ) <= 0
-                    ) {
+                        ) <= 0;
+                    } catch(e) {
+                        let payload = {
+                            error: e.message,
+                        };
+                        self._sendAnalytics("inkscape_version_comparison_error", payload);
+                        console.log("inkscape_version_comparison_error: ", e);
+                        // In case the comparison fails, we assume the version to be above 0.91
+                        // This assumption (the scaling) does not have a major impact as it has
+                        // been the case in the plugin up till 0.10.1-hotfix.2
+                        isOldInkscapeVersion = true;
+                    }
+
+                    if (isOldInkscapeVersion) {
                         //						console.log("old inkscape, px @ 90dpi");
                         declaredUnit = "px_inkscape_old";
                     } else {

--- a/octoprint_mrbeam/static/js/working_area.js
+++ b/octoprint_mrbeam/static/js/working_area.js
@@ -1158,7 +1158,7 @@ $(function () {
             if (declaredUnit === "px" || declaredUnit === "") {
                 if (generator.generator === "inkscape") {
                     if (
-                        WorkingAreaHelper.versionCompare(
+                        window.compareVersions(
                             generator.version,
                             "0.91"
                         ) <= 0

--- a/octoprint_mrbeam/static/js/working_area.js
+++ b/octoprint_mrbeam/static/js/working_area.js
@@ -1158,7 +1158,7 @@ $(function () {
             if (declaredUnit === "px" || declaredUnit === "") {
                 if (generator.generator === "inkscape") {
                     if (
-                        window.compareVersions(
+                        WorkingAreaHelper.versionCompare(
                             generator.version,
                             "0.91"
                         ) <= 0


### PR DESCRIPTION
Inkscape version embedded in SVGs are not Semantic and thus are incompatible with the semver library