### PR TITLE
SW-1077 Increase Laserhead max. working Temperature

### DIFF
--- a/octoprint_mrbeam/__init__.py
+++ b/octoprint_mrbeam/__init__.py
@@ -243,10 +243,10 @@ class MrBeamPlugin(
         self.led_event_listener.set_fps(self._settings.get(["leds", "fps"]))
         # start iobeam socket only once other handlers are already initialized so that we can handle info message
         self.iobeam = ioBeamHandler(self)
-        self.temperature_manager = temperatureManager(self)
         self.dust_manager = dustManager(self)
         self.hw_malfunction_handler = hwMalfunctionHandler(self)
         self.laserhead_handler = laserheadHandler(self)
+        self.temperature_manager = temperatureManager(self)
         self.compressor_handler = compressor_handler(self)
         self.wizard_config = WizardConfig(self)
         self.job_time_estimation = JobTimeEstimation(self)

--- a/octoprint_mrbeam/iobeam/laserhead_handler.py
+++ b/octoprint_mrbeam/iobeam/laserhead_handler.py
@@ -414,8 +414,9 @@ class LaserheadHandler(object):
     def current_laserhead_max_temperature(self):
         """
         Return the current laser head max temperature
+
         Returns:
-        Laser head max temp (float)
+            Laser head max temp (float)
         """
         current_laserhead_properties = self._load_current_laserhead_properties()
 
@@ -436,6 +437,7 @@ class LaserheadHandler(object):
     def _load_current_laserhead_properties(self):
         """
         Loads the current detected laser head related properties and return them
+
         Returns:
             Current laser head properties (dict), (None) otherwise
 
@@ -444,7 +446,7 @@ class LaserheadHandler(object):
         laserhead_id = self.get_current_used_lh_model_id()
 
         # 2. Load the corresponding yaml file and return it's content
-        lh_properties_file_path = os.path.join("/home/pi/oprint/lib/python2.7/site-packages/octoprint_mrbeam",
+        lh_properties_file_path = os.path.join(self._plugin._basefolder,
                                                "profiles", "laserhead", "laserhead_id_{}.yaml".format(laserhead_id))
         if not os.path.isfile(lh_properties_file_path):
             self._logger.exception(

--- a/octoprint_mrbeam/iobeam/laserhead_handler.py
+++ b/octoprint_mrbeam/iobeam/laserhead_handler.py
@@ -416,7 +416,8 @@ class LaserheadHandler(object):
         Return the current laser head max temperature
 
         Returns:
-            Laser head max temp (float)
+            float: Laser head max temp
+
         """
         current_laserhead_properties = self._load_current_laserhead_properties()
 
@@ -439,7 +440,7 @@ class LaserheadHandler(object):
         Loads the current detected laser head related properties and return them
 
         Returns:
-            Current laser head properties (dict), (None) otherwise
+            dict: current laser head properties, None: otherwise
 
         """
         # 1. get the ID of the current laser head

--- a/octoprint_mrbeam/iobeam/laserhead_handler.py
+++ b/octoprint_mrbeam/iobeam/laserhead_handler.py
@@ -4,6 +4,8 @@ import re
 from octoprint_mrbeam.mrb_logger import mrb_logger
 from octoprint_mrbeam.mrbeam_events import MrBeamEvents
 
+LASERHEAD_MAX_TEMP_FALLBACK = 55.0
+
 # singleton
 _instance = None
 
@@ -407,3 +409,65 @@ class LaserheadHandler(object):
                 self._logger.info("Writing to file: {} ..is successful!".format(laser_heads_file))
         except IOError as e:
             self._logger.error("Can't open file: {} , Due to error: {}: ".format(laser_heads_file, e))
+
+    @property
+    def current_laserhead_max_temperature(self):
+        """
+        Return the current laser head max temperature
+        Returns:
+        Laser head max temp (float)
+        """
+        current_laserhead_properties = self._load_current_laserhead_properties()
+
+        # Handle the exceptions
+        if((isinstance(current_laserhead_properties, dict) is False) or
+                ("max_temperature" not in current_laserhead_properties) or
+                (isinstance(current_laserhead_properties["max_temperature"], float) is False)):
+            # Apply fallback
+            self._logger.debug("Current laserhead properties: {}".format(current_laserhead_properties))
+            self._logger.exception(
+                "Current Laserhead Max temp couldn't be retrieved, fallback to the temperature value of: {}".format(
+                    LASERHEAD_MAX_TEMP_FALLBACK))
+            return LASERHEAD_MAX_TEMP_FALLBACK
+        # Reaching here means, everything looks good
+        self._logger.debug("Current Laserhead Max temp:{}".format( current_laserhead_properties["max_temperature"]))
+        return current_laserhead_properties["max_temperature"]
+
+    def _load_current_laserhead_properties(self):
+        """
+        Loads the current detected laser head related properties and return them
+        Returns:
+            Current laser head properties (dict), (None) otherwise
+
+        """
+        # 1. get the ID of the current laser head
+        laserhead_id = self.get_current_used_lh_model_id()
+
+        # 2. Load the corresponding yaml file and return it's content
+        lh_properties_file_path = os.path.join("/home/pi/oprint/lib/python2.7/site-packages/octoprint_mrbeam",
+                                               "profiles", "laserhead", "laserhead_id_{}.yaml".format(laserhead_id))
+        if not os.path.isfile(lh_properties_file_path):
+            self._logger.exception(
+                "properties file for current laser head ID: {} doesn't exist or path is invalid. Path: {}".format(
+                    laserhead_id, lh_properties_file_path))
+            return None
+
+        self._logger.debug(
+            "properties file for current laser head ID: {} exists. Path:{}".format(
+                laserhead_id, lh_properties_file_path) )
+        try:
+            with open(lh_properties_file_path) as lh_properties_yaml_file:
+                self._logger.debug(
+                    "properties file for current laser head ID: {} opened successfully".format(
+                        laserhead_id))
+                return yaml.safe_load(lh_properties_yaml_file)
+        except (IOError, yaml.YAMLError) as e:
+            self._logger.exception(
+                "Exception: {} while Opening or loading the properties file for current laser head. Path: {}".format(
+                    e, lh_properties_file_path))
+            return None
+
+
+
+
+

--- a/octoprint_mrbeam/iobeam/temperature_manager.py
+++ b/octoprint_mrbeam/iobeam/temperature_manager.py
@@ -28,11 +28,7 @@ class TemperatureManager(object):
         self._event_bus = plugin._event_bus
         self.temperature = None
         self.temperature_ts = 0
-        self.temperature_max = (
-            plugin.laserCutterProfileManager.get_current_or_default()["laser"][
-                "max_temperature"
-            ]
-        )
+        self.temperature_max = plugin.laserhead_handler.current_laserhead_max_temperature
         self.hysteresis_temperature = (
             plugin.laserCutterProfileManager.get_current_or_default()["laser"][
                 "hysteresis_temperature"
@@ -91,11 +87,7 @@ class TemperatureManager(object):
         self._shutting_down = True
 
     def reset(self):
-        self.temperature_max = (
-            self._plugin.laserCutterProfileManager.get_current_or_default()["laser"][
-                "max_temperature"
-            ]
-        )
+        self.temperature_max = self._plugin.laserhead_handler.current_laserhead_max_temperature
         self.hysteresis_temperature = (
             self._plugin.laserCutterProfileManager.get_current_or_default()["laser"][
                 "hysteresis_temperature"

--- a/octoprint_mrbeam/printing/profiles/default.py
+++ b/octoprint_mrbeam/printing/profiles/default.py
@@ -18,7 +18,7 @@ profile = dict(
     # if set to onebutton, MR Beam 2 One Button to start laser is activated.
     start_method="onebutton",
     laser=dict(
-        max_temperature=55.0,
+        max_temperature=55.0,   # deprecated, moved to iobeam.laserhead_handler in SW-1077
         hysteresis_temperature=48.0,
         cooling_duration=25,  # if set to positive values: enables time based cooling resuming rather that per hysteresis_temperature
         intensity_factor=13,  # to get from 100% intesity to GCODE-intensity of 1300

--- a/octoprint_mrbeam/profiles/laserhead/laserhead_id_0.yaml
+++ b/octoprint_mrbeam/profiles/laserhead/laserhead_id_0.yaml
@@ -1,0 +1,1 @@
+max_temperature: 55.0

--- a/octoprint_mrbeam/profiles/laserhead/laserhead_id_1.yaml
+++ b/octoprint_mrbeam/profiles/laserhead/laserhead_id_1.yaml
@@ -1,0 +1,1 @@
+max_temperature: 59.0


### PR DESCRIPTION
-- Created new folder profiles-->laserheads which contains laserheads yaml properties
-- Extended iobeam-->laserhead_handler to procide a new property laserhead max temprature
-- Added necessary changes to temperature manager
-- in mrbeam plugin init file, reversed the sequence of the init between temprature manager and laserhead handler for dependency reasons
-- Marked the max laserhead temperature found in default printer profile as deprecated