### PR TITLE
SW-1077-increase-laserhead-max-working-temperature

### DIFF
--- a/octoprint_mrbeam/iobeam/iobeam_handler.py
+++ b/octoprint_mrbeam/iobeam/iobeam_handler.py
@@ -62,6 +62,7 @@ class IoBeamValueEvents(object):
     FAN_FACTOR_RESPONSE = "iobeam.fan.factor.response"
     COMPRESSOR_STATIC = "iobeam.compressor.static"
     COMPRESSOR_DYNAMIC = "iobeam.compressor.dynamic"
+    LASERHEAD_CHANGED = "iobeam.laserhead.changed"
 
 
 class IoBeamHandler(object):

--- a/octoprint_mrbeam/iobeam/temperature_manager.py
+++ b/octoprint_mrbeam/iobeam/temperature_manager.py
@@ -51,7 +51,7 @@ class TemperatureManager(object):
 
         self.dev_mode = plugin._settings.get_boolean(["dev", "iobeam_disable_warnings"])
 
-        msg = "TemperatureManager initialized. temperature_max: {max}, {key}: {value}".format(
+        msg = "TemperatureManager: initialized. temperature_max: {max}, {key}: {value}".format(
             max=self.temperature_max,
             key="cooling_duration"
             if self.mode_time_based
@@ -70,13 +70,15 @@ class TemperatureManager(object):
         self._iobeam = self._plugin.iobeam
         self._analytics_handler = self._plugin.analytics_handler
         self._one_button_handler = self._plugin.onebutton_handler
-
+        self._subscribe()
         self._start_temp_timer()
 
-        self._subscribe()
+
 
     def _subscribe(self):
         self._iobeam.subscribe(IoBeamValueEvents.LASER_TEMP, self.handle_temp)
+
+        self._iobeam.subscribe(IoBeamValueEvents.LASERHEAD_CHANGED, self.reset)
 
         self._event_bus.subscribe(OctoPrintEvents.PRINT_DONE, self.onEvent)
         self._event_bus.subscribe(OctoPrintEvents.PRINT_FAILED, self.onEvent)
@@ -86,7 +88,8 @@ class TemperatureManager(object):
     def shutdown(self):
         self._shutting_down = True
 
-    def reset(self):
+    def reset(self, kwargs):
+        self._logger.info("TemperatureManager: Reset trigger Received : {}".format(kwargs.get("event", None)))
         self.temperature_max = self._plugin.laserhead_handler.current_laserhead_max_temperature
         self.hysteresis_temperature = (
             self._plugin.laserCutterProfileManager.get_current_or_default()["laser"][
@@ -101,7 +104,19 @@ class TemperatureManager(object):
         self.mode_time_based = self.cooling_duration > 0
         self.is_cooling_since = 0
 
+        msg = "TemperatureManager: Reset Done. temperature_max: {max}, {key}: {value}".format(
+            max=self.temperature_max,
+            key="cooling_duration"
+            if self.mode_time_based
+            else "hysteresis_temperature",
+            value=self.cooling_duration
+            if self.mode_time_based
+            else self.hysteresis_temperature,
+        )
+        self._logger.info(msg)
+
     def onEvent(self, event, payload):
+        self._logger.debug("TemperatureManager: Event received: {}".format(event))
         if event == IoBeamValueEvents.LASER_TEMP:
             self.handle_temp(payload)
         elif event in (
@@ -109,7 +124,8 @@ class TemperatureManager(object):
             OctoPrintEvents.PRINT_FAILED,
             OctoPrintEvents.PRINT_CANCELLED,
         ):
-            self.reset()
+
+            self.reset({"event": event})
         elif event == OctoPrintEvents.SHUTDOWN:
             self.shutdown()
 


### PR DESCRIPTION
* Temperature manager to use the current Max Temp value for laser head during init procedure
* In case the laser head changes, The temperature_manager will read the new Max temp value based on the new Laser head detected
* Added new iobeam internal event in case of laserhead changed