### PR TITLE
SW-1226-change-the-cloud-config-to-use-beamos-version-instead-of-date

### DIFF
--- a/tests/softwareupdate/mock_config.json
+++ b/tests/softwareupdate/mock_config.json
@@ -2,7 +2,8 @@
   "default": {
     "type": "github_commit",
     "user": "mrbeam",
-    "release_compare": "unequal",
+    "release_compare": "python_unequal",
+    "force_base": false,
     "stable": {
       "branch": "mrbeam2-stable",
       "branch_default": "mrbeam2-stable",
@@ -59,7 +60,13 @@
     "octoprint": {
       "type": "github_release",
       "develop": {
-        "type": "github_commit"
+        "type": "github_commit",
+        "branch": "alpha",
+        "branch_default": "alpha"
+      },
+      "alpha": {
+        "branch": "alpha",
+        "branch_default": "alpha",
       }
     },
     "mrbeam": {
@@ -84,8 +91,8 @@
           "repo": "MrBeamLedStrips",
           "pip": "https://github.com/mrbeam/MrBeamLedStrips/archive/{target_version}.zip",
           "global_pip_command": true,
-          "beamos_date": {
-            "2021-06-11": {
+          "beamos_version": {
+            "0.18.0": {
               "pip_command": "sudo /usr/local/mrbeam_ledstrips/venv/bin/pip"
             }
           }
@@ -94,8 +101,8 @@
           "repo": "iobeam",
           "pip": "git+ssh://git@bitbucket.org/mrbeam/iobeam.git@{target_version}",
           "global_pip_command": true,
-          "beamos_date": {
-            "2021-06-11": {
+          "beamos_version": {
+            "0.18.0": {
               "pip_command": "sudo /usr/local/iobeam/venv/bin/pip"
             }
           }
@@ -104,8 +111,8 @@
           "repo": "mrb_hw_info",
           "pip": "git+ssh://git@bitbucket.org/mrbeam/mrb_hw_info.git@{target_version}",
           "global_pip_command": true,
-          "beamos_date": {
-            "2021-06-11": {
+          "beamos_version": {
+            "0.18.0": {
               "pip_command": "sudo /usr/local/iobeam/venv/bin/pip"
             }
           }
@@ -126,8 +133,8 @@
           "repo": "netconnectd_mrbeam",
           "pip": "https://github.com/mrbeam/netconnectd_mrbeam/archive/{target_version}.zip",
           "global_pip_command": true,
-          "beamos_date": {
-            "2021-06-11": {
+          "beamos_version": {
+            "0.18.0": {
               "pip_command": "sudo /usr/local/netconnectd/venv/bin/pip"
             }
           }

--- a/tests/softwareupdate/target_find_my_mr_beam_config.json
+++ b/tests/softwareupdate/target_find_my_mr_beam_config.json
@@ -32,7 +32,8 @@
       ]
     }
   ],
-  "release_compare": "unequal",
+  "force_base": false,
+  "release_compare": "python_unequal",
   "tiers": {
     "stable": {
       "branch": "mrbeam2-stable",
@@ -49,7 +50,7 @@
     "develop": {
       "type": "github_commit",
       "branch": "alpha",
-      "branch_default": "alpha",
+      "branch_default": "alpha"
     },
     "alpha": {
       "branch": "mrbeam2-alpha",

--- a/tests/softwareupdate/target_mrbeam_config.json
+++ b/tests/softwareupdate/target_mrbeam_config.json
@@ -5,6 +5,7 @@
   "pip": "https://github.com/mrbeam/MrBeamPlugin/archive/{target_version}.zip",
   "type": "github_commit",
   "user": "mrbeam",
+  "force_base": false,
   "dependencies": {
     "mrbeam-ledstrips": {
       "repo": "MrBeamLedStrips",
@@ -12,8 +13,8 @@
       "global_pip_command": true,
       "displayVersion": "-",
       "pip_command": "sudo /usr/local/bin/pip",
-      "beamos_date": {
-        "2021-06-11": {
+      "beamos_version": {
+        "0.18.0": {
           "pip_command": "sudo /usr/local/mrbeam_ledstrips/venv/bin/pip"
         }
       }
@@ -24,8 +25,8 @@
       "global_pip_command": true,
       "displayVersion": "-",
       "pip_command": "sudo /usr/local/bin/pip",
-      "beamos_date": {
-        "2021-06-11": {
+      "beamos_version": {
+        "0.18.0": {
           "pip_command": "sudo /usr/local/iobeam/venv/bin/pip"
         }
       }
@@ -36,8 +37,8 @@
       "global_pip_command": true,
       "displayVersion": "-",
       "pip_command": "sudo /usr/local/bin/pip",
-      "beamos_date": {
-        "2021-06-11": {
+      "beamos_version": {
+        "0.18.0": {
           "pip_command": "sudo /usr/local/iobeam/venv/bin/pip"
         }
       }
@@ -74,7 +75,7 @@
       ]
     }
   ],
-  "release_compare": "unequal",
+  "release_compare": "python_unequal",
   "tiers": {
     "stable": {
       "branch": "mrbeam2-stable",

--- a/tests/softwareupdate/target_netconnectd_config.json
+++ b/tests/softwareupdate/target_netconnectd_config.json
@@ -6,6 +6,7 @@
     "pip": "https://github.com/mrbeam/OctoPrint-Netconnectd/archive/{target_version}.zip",
     "restart": "environment",
     "type": "github_commit",
+    "force_base": false,
     "dependencies": {
         "netconnectd": {
             "displayVersion": "-",
@@ -13,8 +14,8 @@
             "pip": "https://github.com/mrbeam/netconnectd_mrbeam/archive/{target_version}.zip",
             "global_pip_command": true,
             "pip_command": "sudo /usr/local/bin/pip",
-            "beamos_date": {
-                "2021-06-11": {
+            "beamos_version": {
+                "0.18.0": {
                     "pip_command": "sudo /usr/local/netconnectd/venv/bin/pip",
                 }
             }
@@ -46,7 +47,7 @@
       ]
     }
   ],
-  "release_compare": "unequal",
+  "release_compare": "python_unequal",
   "tiers": {
     "stable": {
       "branch": "mrbeam2-stable",

--- a/tests/softwareupdate/target_octoprint_config.json
+++ b/tests/softwareupdate/target_octoprint_config.json
@@ -5,7 +5,8 @@
     "user": "mrbeam",
     "branch": "alpha",
     "branch_default": "alpha",
-    "release_compare": "unequal",
+    "force_base": false,
+    "release_compare": "python_unequal",
     "stable_branch": {
       "branch": "stable",
       "name": "stable",
@@ -41,7 +42,8 @@
     "user": "mrbeam",
     "branch": "mrbeam2-beta",
     "branch_default": "mrbeam2-beta",
-    "release_compare": "unequal",
+    "force_base": false,
+    "release_compare": "python_unequal",
     "stable_branch": {
       "branch": "stable",
       "name": "stable",
@@ -75,9 +77,10 @@
     "prerelease": true,
     "restart": "environment",
     "user": "mrbeam",
-    "branch": "mrbeam2-alpha",
-    "branch_default": "mrbeam2-alpha",
-    "release_compare": "unequal",
+    "branch": "alpha",
+    "branch_default": "alpha",
+    "force_base": false,
+    "release_compare": "python_unequal",
     "stable_branch": {
       "branch": "stable",
       "name": "stable",
@@ -111,7 +114,8 @@
     "user": "mrbeam",
     "branch": "mrbeam2-stable",
     "branch_default": "mrbeam2-stable",
-    "release_compare": "unequal",
+    "force_base": false,
+    "release_compare": "python_unequal",
     "stable_branch": {
       "branch": "stable",
       "name": "stable",


### PR DESCRIPTION
change the cloud config to use beamos version instead of beamos_date
- refactor beamos_date to beamos_version
- changed comparision to use the version instead of the date
