### PR TITLE
SW-1071-stroke-filling-style-in-svg-is-rendered-differently-in-the-working-area-than-in-the-browser

### DIFF
--- a/octoprint_mrbeam/static/js/helpers/working_area_helper.js
+++ b/octoprint_mrbeam/static/js/helpers/working_area_helper.js
@@ -30,6 +30,7 @@ class WorkingAreaHelper {
     }
 
     static getHexColorStr(inputColor) {
+        // TODO inputColor='none' => '#000000' <- this is a bug
         const c = new Color(inputColor);
         return c.getHex();
     }


### PR DESCRIPTION
Preserve style attr from root node.
Use getComputedStyle for setting fill, fill-rule and stroke on each path