### PR TITLE
SW-1233-replace-server-offline-message-in-octo-print-with-beam-os-not-running

### DIFF
--- a/octoprint_mrbeam/__init__.py
+++ b/octoprint_mrbeam/__init__.py
@@ -694,7 +694,8 @@ class MrBeamPlugin(
                 "css/hopscotch.min.css",
                 "css/wizard.css",
                 "css/tab_messages.css",
-                "css/software_update.css"
+                "css/software_update.css",
+                "css/offline_overlay_text_exchange.css",
             ],
             less=["less/mrbeam.less"],
         )

--- a/octoprint_mrbeam/static/css/offline_overlay_text_exchange.css
+++ b/octoprint_mrbeam/static/css/offline_overlay_text_exchange.css
@@ -1,0 +1,21 @@
+#offline_overlay h1#offline_overlay_title {
+  line-height: 0;
+  color: transparent;
+}
+#offline_overlay h1#offline_overlay_title:after {
+  display: block;
+  content: "BeamOS not running";
+  line-height: initial;
+  color: initial;
+}
+
+#offline_overlay p#offline_overlay_message {
+  line-height: 0;
+  color: transparent;
+}
+#offline_overlay p#offline_overlay_message:after {
+  display: block;
+  content: "Mr Beam is not responding. Maybe he is switched off or currently restarting. I will try again automatically, but you may try it manually using the button below. If this message stays for minutes, please restart your Mr Beam.";
+  line-height: initial;
+  color: initial;
+}


### PR DESCRIPTION
This PR changes the text "Server Offline" and the description in the OctoPrint offline overlay popup. 
The changes are done in a css only solution that we don't have to modify the octoprint code itself. 
The text is currently only available in english. 
Multilanguage could be supported with little effort.  
1. adding translations directly in the css file with an additional language part in the selector (e.g. `body.lang_de #offline_overlay p#offline_overlay_message:after` )
2. adding a class (e.g. "lang_de") to the <body> 