### PR TITLE
SW-1237 develop tier wont install commit based version

### DIFF
--- a/octoprint_mrbeam/scripts/update_script.py
+++ b/octoprint_mrbeam/scripts/update_script.py
@@ -218,6 +218,7 @@ def install_wheels(install_queue):
             "install",
             "--disable-pip-version-check",
             "--upgrade",  # Upgrade all specified packages to the newest available version. The handling of dependencies depends on the upgrade-strategy used.
+            "--force-reinstall",  # Reinstall all packages even if they are already up-to-date.
             "--no-index",  # Ignore package index (only looking at --find-links URLs instead).
             "--find-links={}".format(tmp_folder),  # If a URL or path to an html file, then parse for links to archives such as sdist (.tar.gz) or wheel (.whl) files. If a local path or file:// URL that's a directory, then look for archives in the directory listing. Links to VCS project URLs are not supported.
             "--no-dependencies",  # Don't install package dependencies.


### PR DESCRIPTION
added force reinstall option to pip install in the update script so commit that generate version 0+unknown will be installed again