### PR TITLE
SW-1155 g code files created via pixel based images sv gs engrave some parts more than once

### DIFF
--- a/octoprint_mrbeam/static/js/render_fills.js
+++ b/octoprint_mrbeam/static/js/render_fills.js
@@ -338,10 +338,17 @@ Snap.plugin(function (Snap, Element, Paper, global) {
             //            );
         }
 
-        // TODO only enlarge on images and fonts
-        // Quick fix: in some browsers the bbox is too tight, so we just add an extra 10% to all the sides, making the height and width 20% larger in total
-        const enlargement_x = 0.4; // percentage of the width added to each side
-        const enlargement_y = 0.4; // percentage of the height added to each side
+        // only enlarge on fonts, images not necessary.
+        const doEnlargeBBox =
+            elem.selectAll("text").filter((e) => {
+                const bb = e.getBBox();
+                // this filter is required, as every quick text creates an empty text element (for switching between curved and straight text)
+                return bb.width > 0 && bb.height > 0;
+            }).length > 0;
+
+        // Quick fix: in some browsers the bbox is too tight, so we just add an extra margin to all the sides, making the height and width larger in total
+        const enlargement_x = doEnlargeBBox ? 0.4 : 0; // percentage of the width added to each side
+        const enlargement_y = doEnlargeBBox ? 0.4 : 0; // percentage of the height added to each side
         const x1 = Math.max(0, bbox.x - bbox.width * enlargement_x);
         const x2 = Math.min(wMM, bbox.x2 + bbox.width * enlargement_x);
         const w = x2 - x1;

--- a/octoprint_mrbeam/static/js/render_fills.js
+++ b/octoprint_mrbeam/static/js/render_fills.js
@@ -127,10 +127,12 @@ Snap.plugin(function (Snap, Element, Paper, global) {
             let rasterEl = marked[i];
             let bbox;
             try {
-              bbox = rasterEl.get_total_bbox();
-            }
-            catch(error) {
-                console.warn(`Getting bounding box for ${rasterEl} failed.`, error);
+                bbox = rasterEl.get_total_bbox();
+            } catch (error) {
+                console.warn(
+                    `Getting bounding box for ${rasterEl} failed.`,
+                    error
+                );
                 continue;
             }
             // find overlaps
@@ -172,13 +174,14 @@ Snap.plugin(function (Snap, Element, Paper, global) {
                 rasterEl.addClass(`rasterCluster${c}`)
             );
             let tmpSvg = svg.clone();
-            tmpSvg.selectAll(`.toRaster:not(.rasterCluster${c})`).forEach((element) => {
-                let elementToBeRemoved = tmpSvg.select('#' + element.attr('id'));
-                let elementsToBeExcluded = ["text", "tspan"]
-                if (elementToBeRemoved && !elementsToBeExcluded.includes(elementToBeRemoved.type)) {
-                    elementToBeRemoved.remove();
-                }
-            });
+            tmpSvg.selectAll(`.toRaster:not(.rasterCluster${c})`).remove();
+            // tmpSvg.selectAll(`.toRaster:not(.rasterCluster${c})`).forEach((element) => {
+            //     let elementToBeRemoved = tmpSvg.select('#' + element.attr('id'));
+            //     let elementsToBeExcluded = ["text", "tspan"]
+            //     if (elementToBeRemoved && !elementsToBeExcluded.includes(elementToBeRemoved.type)) {
+            //         elementToBeRemoved.remove();
+            //     }
+            // });
             // Fix IDs of filter references, those are not cloned correct (probably because reference is in style="..." definition)
             tmpSvg.fixIds("defs filter[mb\\:id]", "mb:id"); // namespace attribute selectors syntax: [ns\\:attrname]
             // DON'T fix IDs of textPath references, they're cloned correct.

--- a/octoprint_mrbeam/static/js/snap_helpers.js
+++ b/octoprint_mrbeam/static/js/snap_helpers.js
@@ -66,4 +66,19 @@ Snap.plugin(function (Snap, Element, Paper, global) {
         const bb = el.getBBox();
         return Snap.path.getBBoxWithTransformation(bb, mat);
     };
+
+    /**
+     * filter method for Snap Set like we know it from Array
+     * @param f function which decides wether to keep or discard set elements
+     * @returns {Set<any>} a new Snap set
+     */
+    Snap.Set.prototype.filter = function (f) {
+        const s = new Snap.Set();
+        this.forEach((e) => {
+            if (f(e)) {
+                s.push(e);
+            }
+        });
+        return s;
+    };
 });

--- a/octoprint_mrbeam/static/js/working_area.js
+++ b/octoprint_mrbeam/static/js/working_area.js
@@ -1193,16 +1193,23 @@ $(function () {
                 if (generator.generator === "inkscape") {
                     let isOldInkscapeVersion = NaN;
                     try {
-                        isOldInkscapeVersion= window.compareVersions(
-                            // 1.1.2 (1:1.1+202202050950+0a00cf5339) -> 1.1
-                            generator.version.split('.').slice(0,2).join('.'),
-                            "0.91"
-                        ) <= 0;
-                    } catch(e) {
+                        isOldInkscapeVersion =
+                            window.compareVersions(
+                                // 1.1.2 (1:1.1+202202050950+0a00cf5339) -> 1.1
+                                generator.version
+                                    .split(".")
+                                    .slice(0, 2)
+                                    .join("."),
+                                "0.91"
+                            ) <= 0;
+                    } catch (e) {
                         let payload = {
                             error: e.message,
                         };
-                        self._sendAnalytics("inkscape_version_comparison_error", payload);
+                        self._sendAnalytics(
+                            "inkscape_version_comparison_error",
+                            payload
+                        );
                         console.log("inkscape_version_comparison_error: ", e);
                         // In case the comparison fails, we assume the version to be above 0.91
                         // This assumption (the scaling) does not have a major impact as it has
@@ -1707,7 +1714,7 @@ $(function () {
                     } else if (
                         event.target.classList.contains("unit_percent")
                     ) {
-                        const newWidth =
+                        let newWidth =
                             ((currentWidth / Math.abs(currentSx)) * value) /
                             100.0;
                         if (Math.abs(newWidth) < 0.1)
@@ -1751,7 +1758,7 @@ $(function () {
                     } else if (
                         event.target.classList.contains("unit_percent")
                     ) {
-                        const newHeight =
+                        let newHeight =
                             ((currentHeight / Math.abs(currentSy)) * value) /
                             100.0;
                         if (Math.abs(newHeight) < 0.1)


### PR DESCRIPTION
Fixes the raster pipeline again:

after raster clusters are determined, the svg to draw into canvas only contains the clusters elements.
additionally enlarging bboxes is only done on fonts. Therefore Snap.Set was extended with a .filter(e => ...) method for convenience.
little bugfix in workingarea.js where variables were declared with const but modified afterwards.