### PR TITLE
SW-1259-name-and-version-of-fallback-update-informations-not-correct

### DIFF
--- a/octoprint_mrbeam/software_update_information.py
+++ b/octoprint_mrbeam/software_update_information.py
@@ -57,21 +57,21 @@ BEAMOS_LEGACY_DATE = date(2018, 1, 12)  # still used in the migrations
 FALLBACK_UPDATE_CONFIG = {
     "mrbeam": {
         "displayName": " MrBeam Plugin",
-        "type": "github_commit",
+        "type": "github_release",
         "user": "",
         "repo": "",
         "pip": "",
     },
     "netconnectd": {
         "displayName": "OctoPrint-Netconnectd Plugin",
-        "type": "github_commit",
+        "type": "github_release",
         "user": "",
         "repo": "",
         "pip": "",
     },
     "findmymrbeam": {
         "displayName": "OctoPrint-FindMyMrBeam",
-        "type": "github_commit",
+        "type": "github_release",
         "user": "",
         "repo": "",
         "pip": "",

--- a/tests/softwareupdate/target_mrbeam_config.json
+++ b/tests/softwareupdate/target_mrbeam_config.json
@@ -11,27 +11,23 @@
       "repo": "MrBeamLedStrips",
       "pip": "https://github.com/mrbeam/MrBeamLedStrips/archive/{target_version}.zip",
       "global_pip_command": true,
-      "displayVersion": "-",
       "pip_command": "sudo /usr/local/mrbeam_ledstrips/venv/bin/pip"
     },
     "iobeam": {
       "repo": "iobeam",
       "pip": "git+ssh://git@bitbucket.org/mrbeam/iobeam.git@{target_version}",
       "global_pip_command": true,
-      "displayVersion": "-",
       "pip_command": "sudo /usr/local/iobeam/venv/bin/pip"
     },
     "mrb-hw-info": {
       "repo": "mrb_hw_info",
       "pip": "git+ssh://git@bitbucket.org/mrbeam/mrb_hw_info.git@{target_version}",
       "global_pip_command": true,
-      "displayVersion": "-",
       "pip_command": "sudo /usr/local/iobeam/venv/bin/pip"
     },
     "mrbeamdoc": {
       "pip": "https://github.com/mrbeam/MrBeamDoc/archive/{target_version}.zip",
-      "repo": "MrBeamDoc",
-      "displayVersion": "dummy"
+      "repo": "MrBeamDoc"
     }
   },
   "stable_branch": {

--- a/tests/softwareupdate/target_mrbeam_config_legacy.json
+++ b/tests/softwareupdate/target_mrbeam_config_legacy.json
@@ -11,27 +11,23 @@
       "repo": "MrBeamLedStrips",
       "pip": "https://github.com/mrbeam/MrBeamLedStrips/archive/{target_version}.zip",
       "global_pip_command": true,
-      "displayVersion": "-",
-      "pip_command": "sudo /usr/local/bin/pip",
+      "pip_command": "sudo /usr/local/bin/pip"
     },
     "iobeam": {
       "repo": "iobeam",
       "pip": "git+ssh://git@bitbucket.org/mrbeam/iobeam.git@{target_version}",
       "global_pip_command": true,
-      "displayVersion": "-",
-      "pip_command": "sudo /usr/local/bin/pip",
+      "pip_command": "sudo /usr/local/bin/pip"
     },
     "mrb-hw-info": {
       "repo": "mrb_hw_info",
       "pip": "git+ssh://git@bitbucket.org/mrbeam/mrb_hw_info.git@{target_version}",
       "global_pip_command": true,
-      "displayVersion": "-",
-      "pip_command": "sudo /usr/local/bin/pip",
+      "pip_command": "sudo /usr/local/bin/pip"
     },
     "mrbeamdoc": {
       "pip": "https://github.com/mrbeam/MrBeamDoc/archive/{target_version}.zip",
-      "repo": "MrBeamDoc",
-      "displayVersion": "dummy"
+      "repo": "MrBeamDoc"
     }
   },
   "stable_branch": {

--- a/tests/softwareupdate/target_netconnectd_config.json
+++ b/tests/softwareupdate/target_netconnectd_config.json
@@ -9,7 +9,6 @@
     "force_base": false,
     "dependencies": {
         "netconnectd": {
-            "displayVersion": "-",
             "repo": "netconnectd_mrbeam",
             "pip": "https://github.com/mrbeam/netconnectd_mrbeam/archive/{target_version}.zip",
             "global_pip_command": true,

--- a/tests/softwareupdate/target_netconnectd_config_legacy.json
+++ b/tests/softwareupdate/target_netconnectd_config_legacy.json
@@ -9,7 +9,6 @@
     "force_base": false,
     "dependencies": {
         "netconnectd": {
-            "displayVersion": "-",
             "repo": "netconnectd_mrbeam",
             "pip": "https://github.com/mrbeam/netconnectd_mrbeam/archive/{target_version}.zip",
             "global_pip_command": true,

--- a/tests/softwareupdate/test_cloud_config.py
+++ b/tests/softwareupdate/test_cloud_config.py
@@ -39,7 +39,7 @@ FALLBACK_UPDATE_CONFIG_EXPECTED = {
     "mrbeam": {
         "displayName": " MrBeam Plugin",
         "displayVersion": "dummy",
-        "type": "github_commit",
+        "type": "github_release",
         "user": "",
         "repo": "",
         "pip": "",
@@ -47,7 +47,7 @@ FALLBACK_UPDATE_CONFIG_EXPECTED = {
     "netconnectd": {
         "displayName": "OctoPrint-Netconnectd Plugin",
         "displayVersion": "dummy",
-        "type": "github_commit",
+        "type": "github_release",
         "user": "",
         "repo": "",
         "pip": "",
@@ -55,7 +55,7 @@ FALLBACK_UPDATE_CONFIG_EXPECTED = {
     "findmymrbeam": {
         "displayName": "OctoPrint-FindMyMrBeam",
         "displayVersion": "dummy",
-        "type": "github_commit",
+        "type": "github_release",
         "user": "",
         "repo": "",
         "pip": "",

--- a/tests/softwareupdate/test_cloud_config.py
+++ b/tests/softwareupdate/test_cloud_config.py
@@ -28,13 +28,39 @@ from octoprint_mrbeam.software_update_information import (
     get_update_information,
     SW_UPDATE_INFO_FILE_NAME,
     SW_UPDATE_TIERS,
-    FALLBACK_UPDATE_CONFIG,
 )
 from octoprint_mrbeam.user_notification_system import UserNotificationSystem
 from octoprint_mrbeam.util import dict_merge
 from octoprint_mrbeam.util.device_info import DeviceInfo
 
 TMP_BASE_FOLDER_PATH = "/tmp/cloud_config_test/"
+
+FALLBACK_UPDATE_CONFIG_EXPECTED = {
+    "mrbeam": {
+        "displayName": " MrBeam Plugin",
+        "displayVersion": "dummy",
+        "type": "github_commit",
+        "user": "",
+        "repo": "",
+        "pip": "",
+    },
+    "netconnectd": {
+        "displayName": "OctoPrint-Netconnectd Plugin",
+        "displayVersion": "dummy",
+        "type": "github_commit",
+        "user": "",
+        "repo": "",
+        "pip": "",
+    },
+    "findmymrbeam": {
+        "displayName": "OctoPrint-FindMyMrBeam",
+        "displayVersion": "dummy",
+        "type": "github_commit",
+        "user": "",
+        "repo": "",
+        "pip": "",
+    },
+}
 
 
 class SettingsDummy(object):
@@ -173,7 +199,7 @@ class SoftwareupdateConfigTestCase(unittest.TestCase):
                 status_code=404,
             )
             update_config = get_update_information(plugin)
-            assert update_config == FALLBACK_UPDATE_CONFIG
+            assert update_config == FALLBACK_UPDATE_CONFIG_EXPECTED
         show_notifications_mock.assert_called_with(
             err_msg=[], notification_id="missing_updateinformation_info", replay=False
         )
@@ -215,7 +241,7 @@ class SoftwareupdateConfigTestCase(unittest.TestCase):
                     },
                 )
                 update_config = get_update_information(plugin)
-                assert update_config == FALLBACK_UPDATE_CONFIG
+                assert update_config == FALLBACK_UPDATE_CONFIG_EXPECTED
 
         show_notifications_mock.assert_called_with(
             err_msg=["E-1003"], notification_id="update_fetching_information_err", replay=False
@@ -489,7 +515,7 @@ class SoftwareupdateConfigTestCase(unittest.TestCase):
 
             update_config = get_update_information(plugin)
 
-            self.assertEquals(update_config, FALLBACK_UPDATE_CONFIG)
+            self.assertEquals(update_config, FALLBACK_UPDATE_CONFIG_EXPECTED)
         user_notification_system_show_mock.assert_called_with(
             err_msg=[], notification_id="write_error_update_info_file_err", replay=False
         )


### PR DESCRIPTION
- fixes the fallback update info for offline devices to show the packages and version of the packages correctly