### PR TITLE
SW-1278 quicktext fill color is not being engraved in the latest svg feature branch

### DIFF
--- a/octoprint_mrbeam/static/js/convert.js
+++ b/octoprint_mrbeam/static/js/convert.js
@@ -989,14 +989,12 @@ $(function () {
         // image engraving stuff
         // preset values are a good start for wood engraving
         self.images_placed = ko.observable(false);
-        self.text_placed = ko.observable(false);
-        self.filled_shapes_placed = ko.observable(false);
+        self.filled_text_or_shapes_placed = ko.observable(false);
 
         self.show_image_parameters = ko.computed(function () {
             return (
                 self.images_placed() ||
-                self.text_placed() ||
-                self.filled_shapes_placed()
+                self.filled_text_or_shapes_placed()
             );
         });
 
@@ -1108,9 +1106,8 @@ $(function () {
             self.workingArea.abortFreeTransforms();
             self.gcodeFilesToAppend = self.workingArea.getPlacedGcodes();
             self.show_vector_parameters(self.workingArea.hasStrokedVectors());
-            self.filled_shapes_placed(self.workingArea.hasFilledVectors());
+            self.filled_text_or_shapes_placed(self.workingArea.hasFilledVectors());
             self.images_placed(self.workingArea.getPlacedImages().length > 0);
-            self.text_placed(self.workingArea.hasTextItems());
             self.color_key_update();
 
             // Job Time Estimation 2.0

--- a/octoprint_mrbeam/static/js/render_fills.js
+++ b/octoprint_mrbeam/static/js/render_fills.js
@@ -514,7 +514,7 @@ Snap.plugin(function (Snap, Element, Paper, global) {
                         d: d,
                         // d: `M-5,0h5v-5 ${d}`, // mark the origin for debugging
                         stroke: hex,
-                        fill: "none",
+                        // fill: "none", // removed to fill target path with white fill when no fill exists for easier cursor selection
                     })
                     .transform(mat);
             } else {

--- a/octoprint_mrbeam/static/js/working_area.js
+++ b/octoprint_mrbeam/static/js/working_area.js
@@ -3916,6 +3916,8 @@ $(function () {
                     y: bb.y,
                     width: bb.width,
                     height: bb.height,
+                    // When quicktext fill is enabled/disabled, the fill-opacity controls the inclusion/exclusion of the filling
+                    "fill-opacity": isFilled ? 1 : 0
                 });
 
                 // update font of input field

--- a/octoprint_mrbeam/static/js/working_area.js
+++ b/octoprint_mrbeam/static/js/working_area.js
@@ -3911,6 +3911,14 @@ $(function () {
                     straightText.node.textContent = "";
                     bb = curvedText.getBBox();
                 }
+
+                g.select("path").attr({
+                    // when quicktext outline is disabled, stroke color should be white in order to be ignored
+                    stroke : isStroked ? strokeColor : "#ffffff",
+                    // when quicktext filling is disabled, fill color should be white for easier cursor selection
+                    fill: isFilled ? fill : "#ffffff"
+                });
+
                 g.select("rect").attr({
                     x: bb.x,
                     y: bb.y,


### PR DESCRIPTION
- Modify filled vector detection method for quicktext elements
- Control the filling inclusion/exclusion of the quicktext elements with fill-opacity
- Add white stroke color for stroke exclusion and white filling when none exists for easier cursor selection