### PR TITLE
SW-1355-fix-uptime-for-none-pis

### DIFF
--- a/octoprint_mrbeam/util/uptime.py
+++ b/octoprint_mrbeam/util/uptime.py
@@ -7,9 +7,11 @@ from octoprint_mrbeam.mrb_logger import mrb_logger
 # http://planzero.org/blog/2012/01/26/system_uptime_in_python,_a_better_way
 def get_uptime():
     try:
-        if platform == 'darwin':
-            p = os.popen("uptime")
-            return p.read()
+        if platform == "darwin":
+            mrb_logger("octoprint.plugins.mrbeam.util.uptime").warn(
+                "The uptime is not supported by this hardware and will be set to 0.0"
+            )
+            return 0.0
         else:
             with open("/proc/uptime", "r") as f:
                 uptime = float(f.readline().split()[0])


### PR DESCRIPTION
return 0.0 for the uptime as it is not mandatory and log a warning, this will only show for darwin platforms and will prevent the error from before