### PR TITLE
SW-1328 the text of the svgs will not be engraved

### DIFF
--- a/octoprint_mrbeam/static/js/render_fills.js
+++ b/octoprint_mrbeam/static/js/render_fills.js
@@ -64,7 +64,7 @@ Snap.plugin(function (Snap, Element, Paper, global) {
                 className,
                 fillPaths
             );
-            if (Array.isArray(processedElem) && processedElem?.length === 0) {
+            if (Array.isArray(processedElem) && processedElem.length === 0) {
                 return [];
             } else {
                 selection.push(processedElem);

--- a/octoprint_mrbeam/static/js/render_fills.js
+++ b/octoprint_mrbeam/static/js/render_fills.js
@@ -39,6 +39,7 @@ Snap.plugin(function (Snap, Element, Paper, global) {
         // TODO: better than checking children.length and a blacklist would be to refer to
         // Graphic Elements vs. Container Elements (see https://www.w3.org/TR/SVG/struct.html#TermContainerElement)
         // image is excluded here as <image ...>\n</image> has a child of type #text (== '\n')
+        // text is excluded here as <tspan> cannot be rendered without a <text> parent
         const goRecursive = ![
             "image",
             "defs",
@@ -47,6 +48,7 @@ Snap.plugin(function (Snap, Element, Paper, global) {
             "rdf:rdf",
             "cc:work",
             "sodipodi:namedview",
+            "text",
         ].includes(elem.type);
 
         if (children.length > 0 && goRecursive) {
@@ -64,17 +66,26 @@ Snap.plugin(function (Snap, Element, Paper, global) {
                 elem.type === "text" ||
                 elem.type === "#text"
             ) {
+                // TODO: Check if this is valid for any possible combination otherwise remove
                 if (elem.type === "#text") {
                     if (elem.node.nodeValue.trim() !== "") {
                         let parent = elem.parent();
-                        if (parent.type === "textPath" || parent.type === "tspan") {
+                        if (parent.type === "textPath") {
                             parent = parent.parent();
                         }
                         parent.addClass(className);
                         selection.push(parent);
                     }
                 } else if (elem.type === "text") {
-                    if (elem.node.nodeValue !== null) {
+                    // check if <tspan> elements exist in <text> and if they contain any text
+                    const nonEmptyTspan = (child) =>
+                        child.nodeName === "tspan" &&
+                        child.textContent !== null;
+                    // use node.textContent instead of node.nodeValue as nodeValue returns null regardless of valid fillings
+                    if (
+                        elem.node.textContent !== null ||
+                        Object.values(elem.node.childNodes).some(nonEmptyTspan)
+                    ) {
                         elem.addClass(className);
                         selection.push(elem);
                     }
@@ -343,9 +354,8 @@ Snap.plugin(function (Snap, Element, Paper, global) {
 
             elem.embedAllImages();
             const fontSet = elem.getUsedFonts();
-            const fontDeclarations = WorkingAreaHelper.getFontDeclarations(
-                fontSet
-            );
+            const fontDeclarations =
+                WorkingAreaHelper.getFontDeclarations(fontSet);
 
             let bboxMargin = 0;
             if (margin === null) {

--- a/octoprint_mrbeam/static/js/render_fills.js
+++ b/octoprint_mrbeam/static/js/render_fills.js
@@ -67,7 +67,7 @@ Snap.plugin(function (Snap, Element, Paper, global) {
                 if (elem.type === "#text") {
                     if (elem.node.nodeValue.trim() !== "") {
                         let parent = elem.parent();
-                        if (parent.type === "textPath") {
+                        if (parent.type === "textPath" || parent.type === "tspan") {
                             parent = parent.parent();
                         }
                         parent.addClass(className);

--- a/octoprint_mrbeam/static/js/snap_helpers.js
+++ b/octoprint_mrbeam/static/js/snap_helpers.js
@@ -114,6 +114,7 @@ Snap.plugin(function (Snap, Element, Paper, global) {
     Element.prototype.toWorkingAreaSvgStr = function (
         w,
         h,
+        fontDecl = "",
         styles = "",
         filter = null
     ) {
@@ -124,8 +125,8 @@ Snap.plugin(function (Snap, Element, Paper, global) {
         const vb = ""; //att.viewBox.split(" ");
         const width = w; //vb[2];
         const height = h; // vb[3];
-        if (Array.isArray(styles)) {
-            styles = styles.join("\n");
+        if (Array.isArray(fontDecl)) {
+            fontDecl = fontDecl.join("\n");
         }
         const namespaces = new Set([
             'xmlns="http://www.w3.org/2000/svg"',
@@ -159,6 +160,7 @@ Snap.plugin(function (Snap, Element, Paper, global) {
     xxviewBox="${att.viewBox}">
     <defs>
         ${defs}
+        <style>${fontDecl}</style>
         <style>${styles}</style>
     </defs>
     ${cnt}
@@ -171,12 +173,19 @@ Snap.plugin(function (Snap, Element, Paper, global) {
     Element.prototype.toWorkingAreaDataURL = function (
         w,
         h,
+        fontDecl = "",
         styles = "",
         filter = null
     ) {
         if (window && window.btoa) {
             const elem = this;
-            const svg = elem.toWorkingAreaSvgStr(w, h, styles, filter);
+            const svg = elem.toWorkingAreaSvgStr(
+                w,
+                h,
+                fontDecl,
+                styles,
+                filter
+            );
             const dataurl =
                 "data:image/svg+xml;base64," +
                 btoa(unescape(encodeURIComponent(svg)));

--- a/octoprint_mrbeam/static/js/working_area.js
+++ b/octoprint_mrbeam/static/js/working_area.js
@@ -3222,7 +3222,9 @@ $(function () {
             fillAreas,
             pxPerMM
         ) {
+            // split SVG and get an array of clusters
             let clusters = svg.splitRasterClusters(fillAreas);
+
             // only render clusters overlapping the working area
             const waBB = snap.select("#coordGrid").getBBox();
             clusters = clusters.filter(function (c, idx) {
@@ -3234,13 +3236,16 @@ $(function () {
                 return intersects;
             });
 
+            // get used fonts in text tags
             const whitelist = svg.getUsedFonts();
+            // get font declarations for quickText fonts
             const fontDecl = WorkingAreaHelper.getFontDeclarations(whitelist);
             clusters = clusters.map((c) => {
                 c.svgDataUrl = svg.toWorkingAreaDataURL(
                     self.workingAreaWidthMM(),
                     self.workingAreaHeightMM(),
                     fontDecl,
+                    svg.select("style")?.node?.innerHTML, // include SVG styling
                     `.toRaster.rasterCluster${c.idx}`
                 );
                 return c;

--- a/octoprint_mrbeam/static/js/working_area.js
+++ b/octoprint_mrbeam/static/js/working_area.js
@@ -3249,11 +3249,7 @@ $(function () {
             if (MRBEAM_DEBUG_RENDERING) {
                 debugBase64(
                     clusters.map((c) => {
-                        c.svg.attr(
-                            "viewBox",
-                            `0 0 ${self.workingAreaWidthMM()} ${self.workingAreaHeightMM()}`
-                        );
-                        return c.svg.toDataURL();
+                        return c.svgDataUrl;
                     }),
                     `Step 1: Raster Cluster SVGs`
                 );

--- a/octoprint_mrbeam/templates/conversion_dialog.jinja2
+++ b/octoprint_mrbeam/templates/conversion_dialog.jinja2
@@ -398,6 +398,7 @@
                                                     id="parameter_assignment_engraving_mode_precise_btn"
                                                     data-bind="event: {click: updateEngravingMode}"
                                                     class="btn btn-default active">{{ _('Recommended') }}</button>
+                                            {# TODO: SW-1447 #}
                                             {#<button type="button" value="fast"
                                                     id="parameter_assignment_engraving_mode_fast_btn"
                                                     data-bind="event: {click: updateEngravingMode}"

--- a/octoprint_mrbeam/templates/conversion_dialog.jinja2
+++ b/octoprint_mrbeam/templates/conversion_dialog.jinja2
@@ -398,10 +398,10 @@
                                                     id="parameter_assignment_engraving_mode_precise_btn"
                                                     data-bind="event: {click: updateEngravingMode}"
                                                     class="btn btn-default active">{{ _('Recommended') }}</button>
-                                            <button type="button" value="fast"
+                                            {#<button type="button" value="fast"
                                                     id="parameter_assignment_engraving_mode_fast_btn"
                                                     data-bind="event: {click: updateEngravingMode}"
-                                                    class="btn btn-default">{{ _('Fast') }}</button>
+                                                    class="btn btn-default">{{ _('Fast') }}</button>#}
                                             <button type="button" value="basic"
                                                     id="parameter_assignment_engraving_mode_basic_btn"
                                                     data-bind="event: {click: updateEngravingMode}"


### PR DESCRIPTION
- Hide fast engraving advanced option as Teja decided this option is too buggy and removed the option from the tooltip but forgot the actual button
- Fix MRBEAM_DEBUG_RENDERING debugging as the old method that was still used there breaks the debugging too
- Mark text elements as filled instead of tspan elements: Tspan elements cannot be rendered alone without a text parent leading to some SVG text combinations being skipped
- Add SVG styling to all clusters: Font Declarations are added for quickText fonts but the SVG styling has been left out leading to any text styling being missing. SVG styling is added the same way we are adding the font declarations into the different clusters.