### PR TITLE
SW-1326 the outline and the engraving is not matching the quicktext preview

### DIFF
--- a/octoprint_mrbeam/static/js/render_fills.js
+++ b/octoprint_mrbeam/static/js/render_fills.js
@@ -490,6 +490,12 @@ Snap.plugin(function (Snap, Element, Paper, global) {
                         // fill: "none", // removed to fill target path with white fill when no fill exists for easier cursor selection
                     })
                     .transform(mat);
+
+                // remove stroke from text element to avoid thick stroke engraving
+                // the .qt_outline element will be used for stroke cutting or engraving
+                elem.attr({
+                    stroke: "none",
+                });
             } else {
                 console.error("getFontOutline(): failed.");
             }

--- a/octoprint_mrbeam/static/js/working_area.js
+++ b/octoprint_mrbeam/static/js/working_area.js
@@ -3921,8 +3921,8 @@ $(function () {
                     // add selected attributes to stroke path
                     g.select("path").attr({
                         stroke: strokeColor,
-                        fill: isFilled ? fill : "#ffffff",
-                        "fill-opacity": isFilled ? 1 : 0,
+                        fill: "#ffffff",
+                        "fill-opacity": 0,
                     });
                 } else {
                     qtOutlineGroup.select("path")?.remove();


### PR DESCRIPTION
- SW-1326 Modify fill attribute and fill-opacity style
These attribute and styling should always be set to white and zero so that the outline path always have transparent filling. The filling of the quicktext is handled by another text element.
 
- SW-1326 Set stroke in the text element to none
This stroke is used to detect the availability of an outline. The outline will be handled in the .qt_outline element. This should be removed at the last point before added to the working area otherwise it will be lasered as a thick stroke included with the filling whenever filling and outline are checked together.