### PR TITLE
SW-2351 modifications to cypress workflow

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -146,7 +146,7 @@ jobs:
           tested_issue_assignee=$(printf '%s' $tested_issue_details | jq --raw-output .fields.assignee.accountId)
           echo $tested_issue_assignee
 
-          tested_issue_fix_version=$(printf '%s' '$tested_issue_details' | jq -r .fields.fixVersions[].name)
+          tested_issue_fix_version=$(printf '%s' $tested_issue_details | jq -r .fields.fixVersions[].name)
           echo $tested_issue_fix_version
 
           curl -D- -u ${{ secrets.JIRA_SW_EMAIL }}:${{ secrets.JIRA_SW_API_TOKEN }} \
@@ -155,7 +155,7 @@ jobs:
               '{
                 "fields": {
                   "summary": "[GitHub:Cypress] '"$test_exec_summary"'",
-                  "assignee": { "accountId": "$tested_issue_assignee" }
+                  "assignee": { "accountId": "'"$tested_issue_assignee"'" }
                 },
                 "update": {
                   "issuelinks": [
@@ -173,7 +173,7 @@ jobs:
                   ],
                   "fixVersions": [
                     {
-                      "add": {"name": "'"tested_issue_fix_version"'"}
+                      "add": {"name": "'"$tested_issue_fix_version"'"}
                     }
                   ]
                 }

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -17,7 +17,7 @@ env:
 
 jobs:
   mrb-docker:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     outputs:
       domain: ${{ env.MRBEAM_PLUGIN_DOMAIN_NAME }}
     steps:
@@ -42,7 +42,7 @@ jobs:
           path: /tmp/image.tar
 
   ui-chrome-tests:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     permissions: write-all
     container:
       image: cypress/browsers:node16.17.0-chrome106
@@ -99,7 +99,7 @@ jobs:
           path: cypress/results
 
   xray-import:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     needs: ui-chrome-tests
     if: always()
     steps:

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -125,26 +125,37 @@ jobs:
           token=$(curl -H "Content-Type: application/json" -X POST --data '{ "client_id": "${{ secrets.JIRA_CLIENT_ID }}","client_secret": "${{ secrets.JIRA_CLIENT_SECRET }}" }'  https://xray.cloud.getxray.app/api/v2/authenticate| tr -d '"')
           xray_import_response=$(curl -H "Content-Type: text/xml" -X POST -H "Authorization: Bearer $token"  --data @"cypress/results/combined.xml" ${{ env.XRAY_JUNIT_IMPORT }}?projectKey=${{ env.JIRA_PROJECT_KEY }}&testPlanKey=${{ env.TEST_PLAN_KEY }})
           echo "xray_import_response=$xray_import_response" >> $GITHUB_OUTPUT
-      - name: Change issue summary and add link
-        # issue_url: extracts the newly created test execution issue url from the previous response
-        # issue_name: contains the latest commit message. Should be something like "SW-1234 summary"
-        # tests_issue: extracts the "SW-1234" from the commit message, to add it as a link to the text execution issue
+      - name: Change test execution issue details
+        # test_exec_id: extracts the newly created test execution issue url from the previous response
+        # test_exec_summary: contains the latest commit message. Should be something like "SW-1234 summary"
+        # tested_issue_id: extracts the "SW-1234" from the commit message, to add it as a link to the text execution issue
+        # tested_issue_assignee: extracts the accountId of the assignee of the tested ticket
+        # tested_issue_fix_version: extracts the fixVersion of the tested ticket
         run: |
-          issue_url=$(printf '%s\n' '${{ steps.xray.outputs.xray_import_response }}' | jq -r .self)
-          echo $issue_url
+          test_exec_url=$(printf '%s\n' '${{ steps.xray.outputs.xray_import_response }}' | jq -r .self)
+          echo $test_exec_url
 
           last_commit_message=$(echo $(git log -1 --pretty=format:"%s"))
-          issue_name="Test execution for $last_commit_message"
-          echo $issue_name
+          test_exec_summary="Test execution for $last_commit_message"
+          echo $test_exec_summary
 
-          tests_issue=$(echo $last_commit_message | sed -E -e 's/.*(SW-[0-9]+).*/\1/g')
-          echo $tests_issue
+          tested_issue_id=$(echo $last_commit_message | sed -E -e 's/.*(SW-[0-9]+).*/\1/g')
+          echo $tested_issue_id
 
-          curl -D- -u ${{ secrets.JIRA_SW_EMAIL }}:${{ secrets.JIRA_SW_API_TOKEN }} -X PUT $issue_url -H 'Content-Type: application/json' \
+          tested_issue_details=$(curl -u ${{ secrets.JIRA_SW_EMAIL }}:${{ secrets.JIRA_SW_API_TOKEN }} -X GET 'https://mr-beam.atlassian.net/rest/api/2/issue/'$tested_issue_id )
+          tested_issue_assignee=$(printf '%s' $tested_issue_details | jq --raw-output .fields.assignee.accountId)
+          echo $tested_issue_assignee
+
+          tested_issue_fix_version=$(printf '%s' '$tested_issue_details' | jq -r .fields.fixVersions[].name)
+          echo $tested_issue_fix_version
+
+          curl -D- -u ${{ secrets.JIRA_SW_EMAIL }}:${{ secrets.JIRA_SW_API_TOKEN }} \
+            -X PUT $test_exec_url -H 'Content-Type: application/json' \
             --data \
               '{
                 "fields": {
-                  "summary": "[GitHub:Cypress] '"$issue_name"'"
+                  "summary": "[GitHub:Cypress] '"$test_exec_summary"'",
+                  "assignee": { "accountId": "$tested_issue_assignee" }
                 },
                 "update": {
                   "issuelinks": [
@@ -155,10 +166,22 @@ jobs:
                           "outward":"tests"
                         },
                         "outwardIssue": {
-                          "key": "'"$tests_issue"'"
+                          "key": "'"$tested_issue_id"'"
                         }
                       }
+                    }
+                  ],
+                  "fixVersions": [
+                    {
+                      "add": {"name": "'"tested_issue_fix_version"'"}
                     }
                   ]
                 }
               }'
+
+      - name: Move test execution to done
+        # 21 is the id for the status "Done"
+        run: |
+          curl -D- -u ${{ secrets.JIRA_SW_EMAIL }}:${{ secrets.JIRA_SW_API_TOKEN }} \
+            -X POST $test_exec_url'/transitions' -H 'Content-Type: application/json' \
+            --data '{ "transition": { "id": "21" } }'

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -138,7 +138,7 @@ jobs:
           echo "test_exec_url=$test_exec_url" >> $GITHUB_OUTPUT
 
           last_commit_message=$(echo $(git log -1 --pretty=format:"%s"))
-          test_exec_summary="Test execution for $last_commit_message"
+          test_exec_summary=$(echo "Test execution for $last_commit_message" | tr \" " ")
           echo $test_exec_summary
 
           tested_issue_id=$(echo $last_commit_message | sed -E -e 's/.*(SW-[0-9]+).*/\1/g')

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -126,6 +126,7 @@ jobs:
           xray_import_response=$(curl -H "Content-Type: text/xml" -X POST -H "Authorization: Bearer $token"  --data @"cypress/results/combined.xml" ${{ env.XRAY_JUNIT_IMPORT }}?projectKey=${{ env.JIRA_PROJECT_KEY }}&testPlanKey=${{ env.TEST_PLAN_KEY }})
           echo "xray_import_response=$xray_import_response" >> $GITHUB_OUTPUT
       - name: Change test execution issue details
+        id: issue-details
         # test_exec_id: extracts the newly created test execution issue url from the previous response
         # test_exec_summary: contains the latest commit message. Should be something like "SW-1234 summary"
         # tested_issue_id: extracts the "SW-1234" from the commit message, to add it as a link to the text execution issue
@@ -134,6 +135,7 @@ jobs:
         run: |
           test_exec_url=$(printf '%s\n' '${{ steps.xray.outputs.xray_import_response }}' | jq -r .self)
           echo $test_exec_url
+          echo "test_exec_url=$test_exec_url" >> $GITHUB_OUTPUT
 
           last_commit_message=$(echo $(git log -1 --pretty=format:"%s"))
           test_exec_summary="Test execution for $last_commit_message"
@@ -148,6 +150,7 @@ jobs:
 
           tested_issue_fix_version=$(printf '%s' $tested_issue_details | jq -r .fields.fixVersions[].name)
           echo $tested_issue_fix_version
+          echo "tested_issue_fix_version=$tested_issue_fix_version" >> $GITHUB_OUTPUT
 
           curl -D- -u ${{ secrets.JIRA_SW_EMAIL }}:${{ secrets.JIRA_SW_API_TOKEN }} \
             -X PUT $test_exec_url -H 'Content-Type: application/json' \
@@ -170,10 +173,22 @@ jobs:
                         }
                       }
                     }
-                  ],
+                  ]
+                }
+              }'
+
+      - name: Add fix version if available
+        continue-on-error: true
+        if: ${{ steps.issue-details.outputs.tested_issue_fix_version }}
+        run: |
+          curl -D- -u ${{ secrets.JIRA_SW_EMAIL }}:${{ secrets.JIRA_SW_API_TOKEN }} \
+            -X PUT ${{ steps.issue-details.outputs.test_exec_url }} -H 'Content-Type: application/json' \
+            --data \
+              '{
+                "update": {
                   "fixVersions": [
                     {
-                      "add": {"name": "'"$tested_issue_fix_version"'"}
+                      "add": {"name": "'"${{ steps.issue-details.outputs.tested_issue_fix_version }}"'"}
                     }
                   ]
                 }
@@ -182,6 +197,7 @@ jobs:
       - name: Move test execution to done
         # 21 is the id for the status "Done"
         run: |
+          echo ${{ steps.issue-details.outputs.test_exec_url }}
           curl -D- -u ${{ secrets.JIRA_SW_EMAIL }}:${{ secrets.JIRA_SW_API_TOKEN }} \
-            -X POST $test_exec_url'/transitions' -H 'Content-Type: application/json' \
+            -X POST ${{ steps.issue-details.outputs.test_exec_url }}'/transitions' -H 'Content-Type: application/json' \
             --data '{ "transition": { "id": "21" } }'

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -11,6 +11,9 @@ env:
   # These two are just for internal use, to wire the container network
   MRBEAM_PLUGIN_URL: "http://plugin-address.org:5002/"
   MRBEAM_PLUGIN_DOMAIN_NAME: "plugin-address.org"
+  JIRA_PROJECT_KEY: "SW"
+  XRAY_JUNIT_IMPORT: "https://xray.cloud.getxray.app/api/v2/import/execution/junit"
+  TEST_PLAN_KEY: "SW-2354"
 
 jobs:
   mrb-docker:
@@ -120,7 +123,7 @@ jobs:
         id: xray
         run: |
           token=$(curl -H "Content-Type: application/json" -X POST --data '{ "client_id": "${{ secrets.JIRA_CLIENT_ID }}","client_secret": "${{ secrets.JIRA_CLIENT_SECRET }}" }'  https://xray.cloud.getxray.app/api/v2/authenticate| tr -d '"')
-          xray_import_response=$(curl -H "Content-Type: text/xml" -X POST -H "Authorization: Bearer $token"  --data @"cypress/results/combined.xml" https://xray.cloud.getxray.app/api/v2/import/execution/junit?projectKey=SW)
+          xray_import_response=$(curl -H "Content-Type: text/xml" -X POST -H "Authorization: Bearer $token"  --data @"cypress/results/combined.xml" ${{ env.XRAY_JUNIT_IMPORT }}?projectKey=${{ env.JIRA_PROJECT_KEY }}&testPlanKey=${{ env.TEST_PLAN_KEY }})
           echo "xray_import_response=$xray_import_response" >> $GITHUB_OUTPUT
       - name: Change issue summary and add link
         # issue_url: extracts the newly created test execution issue url from the previous response
@@ -151,7 +154,7 @@ jobs:
                           "name":"Test",
                           "outward":"tests"
                         },
-                        "outwardIssue" : {
+                        "outwardIssue": {
                           "key": "'"$tests_issue"'"
                         }
                       }

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -197,7 +197,6 @@ jobs:
       - name: Move test execution to done
         # 21 is the id for the status "Done"
         run: |
-          echo ${{ steps.issue-details.outputs.test_exec_url }}
           curl -D- -u ${{ secrets.JIRA_SW_EMAIL }}:${{ secrets.JIRA_SW_API_TOKEN }} \
             -X POST ${{ steps.issue-details.outputs.test_exec_url }}'/transitions' -H 'Content-Type: application/json' \
             --data '{ "transition": { "id": "21" } }'

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -17,7 +17,7 @@ env:
 
 jobs:
   mrb-docker:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     outputs:
       domain: ${{ env.MRBEAM_PLUGIN_DOMAIN_NAME }}
     steps:
@@ -42,7 +42,7 @@ jobs:
           path: /tmp/image.tar
 
   ui-chrome-tests:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     permissions: write-all
     container:
       image: cypress/browsers:node16.17.0-chrome106
@@ -99,7 +99,7 @@ jobs:
           path: cypress/results
 
   xray-import:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     needs: ui-chrome-tests
     if: always()
     steps:

--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -141,7 +141,7 @@ jobs:
             --data \
               '{
                 "fields": {
-                  "summary": "'"$issue_name"'"
+                  "summary": "[GitHub:Cypress] '"$issue_name"'"
                 },
                 "update": {
                   "issuelinks": [


### PR DESCRIPTION
- Add fix version
-  Change test execution name to: [GitHub:Cypress] xxx 
- Set status to Done 
- Create test plan "Test automation GitHub/Cypress" and link all test executions to that plan
- Add assignee to the test execution, matching the assignee of the ticket