### PR TITLE
SW-1931 lazy load design store

### DIFF
--- a/octoprint_mrbeam/model/settings_model.py
+++ b/octoprint_mrbeam/model/settings_model.py
@@ -27,9 +27,10 @@ class MaterialStoreModel:
         Data object containing information corresponding to the material store section to be used on the jinja2 templates
         """
 
-    def __init__(self, enabled=False, url=""):
+    def __init__(self, enabled=False, url="", healthcheck_url=""):
         self.enabled = enabled
         self.url = url
+        self.healthcheck_url = healthcheck_url
 
     def __repr__(self):
-        return 'MaterialStore(enabled=%s, url=%s)' % (self.enabled, self.url)
+        return 'MaterialStore(enabled=%s, url=%s, healthcheck_url=%s)' % (self.enabled, self.url, self.healthcheck_url)

--- a/octoprint_mrbeam/services/settings_service.py
+++ b/octoprint_mrbeam/services/settings_service.py
@@ -90,6 +90,7 @@ class SettingsService:
                                                                                      environment)
                     material_store_settings.enabled = material_store_config.enabled
                     material_store_settings.url = material_store_config.url
+                    material_store_settings.healthcheck_url = material_store_config.healthcheck_url
                 except yaml.YAMLError as e:
                     self._logger.error('Material store settings couldn\'t be parsed. Exception %s', e)
 
@@ -101,6 +102,7 @@ class SettingsService:
             env_config_yml = material_store_config_yml['material-store']['environment'][environment.value.lower()]
             material_store_config.enabled = env_config_yml['enabled']
             material_store_config.url = env_config_yml['url']
+            material_store_config.healthcheck_url = env_config_yml['healthcheck_url']
         else:
             self._logger.warn(
                 'Couldn\'t find corresponding material store configuration to current environment -> %s <-',
@@ -114,4 +116,5 @@ class SettingsService:
                        environment.value.lower() in material_store_config_yml['material-store']['environment']) and (
                        'enabled' in material_store_config_yml['material-store']['environment'][
                    environment.value.lower()]) and ('url' in material_store_config_yml['material-store']['environment'][
+            environment.value.lower()]) and ('healthcheck_url' in material_store_config_yml['material-store']['environment'][
             environment.value.lower()])

--- a/octoprint_mrbeam/services/settings_service.py
+++ b/octoprint_mrbeam/services/settings_service.py
@@ -73,7 +73,6 @@ class SettingsService:
         settings_model.about = AboutModel(
             support_documents=[self._document_service.get_documents_for(definition) for definition in definitions])
 
-        self._logger.info("SettingsModel -> %s", str(settings_model))
         return settings_model
 
     def _get_material_store_settings(self, environment):

--- a/octoprint_mrbeam/static/css/mrbeam.css
+++ b/octoprint_mrbeam/static/css/mrbeam.css
@@ -3401,6 +3401,26 @@ button#terminal-send {
   margin-top: 45px;
 }
 
+#designstore .loading_spinner_wrapper {
+  position: absolute;
+  top: 0px;
+  left: 0px;
+  height: 100%;
+  width: 100%;
+  z-index: 1000;
+  background: rgba(0, 0, 0, 0.5);
+}
+#designstore .loading_spinner {
+  position: relative;
+  left: 50%;
+  top: 50%;
+  color: #ffffff;
+}
+#designstore .loading_spinner i {
+  font-weight: bold;
+  font-size: 4em;
+}
+
 /* Design Store */
 
 /* Support Standalone */

--- a/octoprint_mrbeam/static/js/design_store.js
+++ b/octoprint_mrbeam/static/js/design_store.js
@@ -9,6 +9,7 @@ $(function () {
         // staging:
         // 'https://1-0-0-staging-dot-design-store-269610.appspot.com'
         // 'http://localhost:8080';
+        self.DESIGN_STORE_IFRAME_HEALTHCHECK_SRC = self.DESIGN_STORE_IFRAME_SRC + "/api/healthcheck";
 
         self.loginState = params[0];
         self.navigation = params[1];
@@ -18,8 +19,9 @@ $(function () {
         self.lastUploadedDate = ko.observable("");
         self.eventListenerAdded = ko.observable(false);
 
-        self.onUserLoggedIn = function () {
+        self.initialiseStore = function () {
             self.prepareDesignStoreTab();
+            self.goToStore();
         };
 
         self.getUserSettings = function () {

--- a/octoprint_mrbeam/static/js/design_store.js
+++ b/octoprint_mrbeam/static/js/design_store.js
@@ -20,8 +20,20 @@ $(function () {
         self.eventListenerAdded = ko.observable(false);
 
         self.initialiseStore = function () {
-            self.prepareDesignStoreTab();
-            self.goToStore();
+            let designStoreIframeElement = $("#design_store_iframe");
+            if(designStoreIframeElement.attr("src") !== self.DESIGN_STORE_IFRAME_SRC){
+                self.prepareDesignStoreTab();
+                self.goToStore();
+                // Handle design store if offline
+                // This will show the network issue page if the device is offline
+                // However, if the device gets online afterwards, this will not change
+                // until the user refreshes the page
+                if(!window.mrbeam.isOnline) {
+                    $("#designstore > .loading_spinner_wrapper").hide();
+                    $("#design_store_iframe").hide();
+                    $("#design_store_offline_placeholder").show();
+                }
+            }
         };
 
         self.getUserSettings = function () {
@@ -126,7 +138,7 @@ $(function () {
 
         self.onDiscoveryReceived = function () {
             $("#design_store_iframe").show();
-            $("#design_store_offline_placeholder").hide();
+            $("#designstore > .loading_spinner_wrapper").hide();
 
             // TODO: remove the following Version sanitization once the version
             //  comparative methods support "pep440" versioning (SW-1047)
@@ -284,8 +296,8 @@ $(function () {
             setTimeout(function () {
                 refreshButtonElement.text(refreshButtonText);
             }, 3000);
-            document.getElementById("design_store_iframe").src =
-                self.DESIGN_STORE_IFRAME_SRC;
+            document.getElementById("design_store_iframe").src = "#";
+            self.initialiseStore();
         };
     }
 

--- a/octoprint_mrbeam/static/js/design_store.js
+++ b/octoprint_mrbeam/static/js/design_store.js
@@ -260,6 +260,9 @@ $(function () {
         };
 
         self.goToStore = function () {
+            // Lazy load the iframe
+            $("#design_store_iframe").attr('loading', 'eager');
+            // Handle the new designs notification icon
             $("#designstore_tab_btn > span.red-dot").remove();
             if ($("#designstore_tab_btn").parent().hasClass("active")) {
                 self.sendMessageToDesignStoreIframe("goToStore", {});

--- a/octoprint_mrbeam/static/js/material-store.js
+++ b/octoprint_mrbeam/static/js/material-store.js
@@ -72,12 +72,14 @@ $(function () {
                 payload: payload,
             };
 
-            if(materialStoreIframeElement.is(":visible")){
+            if(materialStoreIframeElement.contentWindow){
                 materialStoreIframeElement
                     .contentWindow.postMessage(
                         data,
                         self.material_store_iframe_src
                     );
+            } else {
+                console.error("Material store Iframe window object is undefined");
             }
         };
 

--- a/octoprint_mrbeam/static/js/material-store.js
+++ b/octoprint_mrbeam/static/js/material-store.js
@@ -10,8 +10,9 @@ $(function () {
         window.mrbeam.viewModels["materialStoreViewModel"] = self;
         self.material_store_iframe_src = "";
 
-        self.initialiseStore = function (url) {
-            if (typeof url === "string" && url.trim().length !== 0) {
+        self.initialiseStore = function (healthcheck_url, url) {
+            if (typeof url === "string" && url.trim().length !== 0
+            && typeof healthcheck_url === "string" && healthcheck_url.trim().length !== 0) {
                 if (url !== self.material_store_iframe_src) {
                     self.material_store_iframe_src = url;
                     $("#material_store_iframe").attr(
@@ -21,7 +22,7 @@ $(function () {
                 }
 
                 $.ajax({
-                    url: self.material_store_iframe_src,
+                    url: healthcheck_url,
                     method: "HEAD",
                     timeout: 6000,
                     success: self.loadMaterialStore,

--- a/octoprint_mrbeam/static/js/material-store.js
+++ b/octoprint_mrbeam/static/js/material-store.js
@@ -71,12 +71,15 @@ $(function () {
                 payload: payload,
             };
 
-            document
-                .getElementById("material_store_iframe")
-                .contentWindow.postMessage(
-                    data,
-                    self.material_store_iframe_src
-                );
+            let materialStoreIframeElement = $("#material_store_iframe");
+
+            if(materialStoreIframeElement.is(":visible")){
+                materialStoreIframeElement
+                    .contentWindow.postMessage(
+                        data,
+                        self.material_store_iframe_src
+                    );
+            }
         };
 
         $("#material_store_iframe").attr("src", self.material_store_iframe_src);

--- a/octoprint_mrbeam/static/js/material-store.js
+++ b/octoprint_mrbeam/static/js/material-store.js
@@ -66,12 +66,11 @@ $(function () {
         };
 
         self.sendMessageToMaterialStoreIframe = function (event, payload) {
+            let materialStoreIframeElement = $("#material_store_iframe");
             let data = {
                 event: event,
                 payload: payload,
             };
-
-            let materialStoreIframeElement = $("#material_store_iframe");
 
             if(materialStoreIframeElement.is(":visible")){
                 materialStoreIframeElement

--- a/octoprint_mrbeam/templates/mrbeam_ui_index.jinja2
+++ b/octoprint_mrbeam/templates/mrbeam_ui_index.jinja2
@@ -53,7 +53,7 @@
 					<li><a href="#designlib" data-toggle="tab" id="designlib_tab_btn">{{ _('design library') }}</a></li>
                     <li><a href="#designstore" data-toggle="tab" id="designstore_tab_btn" onclick="window.mrbeam.viewModels.designStoreViewModel.goToStore()">{{ _('design store') }}</a></li>
                     {% if settings_model.material_store.enabled %}
-                        <li><a href="#material_store_content" data-toggle="tab" id="materialsotre_tab_btn" onclick="window.mrbeam.viewModels.materialStoreViewModel.initialiseStore('{{ settings_model.material_store.url }}')">{{ _('material store') }}</a></li>
+                        <li><a href="#material_store_content" data-toggle="tab" id="materialsotre_tab_btn" onclick="window.mrbeam.viewModels.materialStoreViewModel.initialiseStore('{{ settings_model.material_store.healthcheck_url }}', '{{ settings_model.material_store.url }}')">{{ _('material store') }}</a></li>
                     {% endif %}
                     {% if not enableFocus %}
 					<li><a href="#focus" data-toggle="tab" id="focus_tab_btn">{{ _('focus') }}</a></li>

--- a/octoprint_mrbeam/templates/mrbeam_ui_index.jinja2
+++ b/octoprint_mrbeam/templates/mrbeam_ui_index.jinja2
@@ -51,7 +51,7 @@
 					<li class="active"><a href="#workingarea" data-toggle="tab" id="wa_tab_btn">{{ _('working area') }}</a></li>
                     {# Translatots: Name of the tab #}
 					<li><a href="#designlib" data-toggle="tab" id="designlib_tab_btn">{{ _('design library') }}</a></li>
-                    <li><a href="#designstore" data-toggle="tab" id="designstore_tab_btn" onclick="window.mrbeam.viewModels.designStoreViewModel.goToStore()">{{ _('design store') }}</a></li>
+                    <li><a href="#designstore" data-toggle="tab" id="designstore_tab_btn" onclick="window.mrbeam.viewModels.materialStoreViewModel.initialiseStore()">{{ _('design store') }}</a></li>
                     {% if settings_model.material_store.enabled %}
                         <li><a href="#material_store_content" data-toggle="tab" id="materialsotre_tab_btn" onclick="window.mrbeam.viewModels.materialStoreViewModel.initialiseStore('{{ settings_model.material_store.healthcheck_url }}', '{{ settings_model.material_store.url }}')">{{ _('material store') }}</a></li>
                     {% endif %}

--- a/octoprint_mrbeam/templates/mrbeam_ui_index.jinja2
+++ b/octoprint_mrbeam/templates/mrbeam_ui_index.jinja2
@@ -51,7 +51,7 @@
 					<li class="active"><a href="#workingarea" data-toggle="tab" id="wa_tab_btn">{{ _('working area') }}</a></li>
                     {# Translatots: Name of the tab #}
 					<li><a href="#designlib" data-toggle="tab" id="designlib_tab_btn">{{ _('design library') }}</a></li>
-                    <li><a href="#designstore" data-toggle="tab" id="designstore_tab_btn" onclick="window.mrbeam.viewModels.materialStoreViewModel.initialiseStore()">{{ _('design store') }}</a></li>
+                    <li><a href="#designstore" data-toggle="tab" id="designstore_tab_btn" onclick="window.mrbeam.viewModels.designStoreViewModel.initialiseStore()">{{ _('design store') }}</a></li>
                     {% if settings_model.material_store.enabled %}
                         <li><a href="#material_store_content" data-toggle="tab" id="materialsotre_tab_btn" onclick="window.mrbeam.viewModels.materialStoreViewModel.initialiseStore('{{ settings_model.material_store.healthcheck_url }}', '{{ settings_model.material_store.url }}')">{{ _('material store') }}</a></li>
                     {% endif %}

--- a/octoprint_mrbeam/templates/mrbeam_ui_index.jinja2
+++ b/octoprint_mrbeam/templates/mrbeam_ui_index.jinja2
@@ -124,7 +124,7 @@
                     {% endif %}
 					{% include 'tab_designlib.jinja2' %}
                     {% include 'tab_messages.jinja2' %}
-                    {% include 'tab_designstore.jinja2' %}
+                    {% include 'tab/tab_designstore.jinja2' %}
                     {% if settings_model.material_store.enabled %}
                         {% include 'tab/tab_materialstore.jinja2' %}
                     {% endif %}

--- a/octoprint_mrbeam/templates/tab/tab_designstore.jinja2
+++ b/octoprint_mrbeam/templates/tab/tab_designstore.jinja2
@@ -1,9 +1,13 @@
-
 <div class="tab-pane" id="designstore">
-    <iframe id="design_store_iframe" scrolling="auto" frameBorder="0"></iframe>
-    <div id="design_store_offline_placeholder">
-{#        Seems like you are not connected to the internet. If you want to use the Design Store, please connect to the internet and reload the page.#}
+    <div class="loading_spinner_wrapper">
+        <div class="loading_spinner">
+            <i class="icon icon-spinner icon-spin"></i>
+        </div>
+    </div>
 
+    <iframe loading="lazy" id="design_store_iframe" scrolling="auto" frameBorder="0"></iframe>
+
+    <div id="design_store_offline_placeholder" class="hidden">
         <div class="row-fluid no-internet-connection-section">
             <div class="span12">
                 <div class="row-fluid">

--- a/tests/services/test_settings_service.py
+++ b/tests/services/test_settings_service.py
@@ -92,7 +92,7 @@ class TestSettingsService(TestCase):
     def test_get_template_settings_model_with_no_matching_environment_material_store_settings__then_empty_material_store_settings(
             self, yaml_mock, requests_mock):
         yaml_mock.return_value = {'material-store': {
-            'environment': {'doesnotexist': {'url': 'https://test.material.store.mr-beam.org', 'enabled': True}}}}
+            'environment': {'doesnotexist': {'url': 'https://test.material.store.mr-beam.org', 'enabled': True, 'healthcheck_url': 'https://test.material.store.mr-beam.org/api/healthcheck'}}}}
         settings_model = self._settings_service.get_template_settings_model(MrBeamModel.DREAMCUT_S.value)
         self._validate_settings_model(settings_model)
         self._validate_empty_material_store_settings(settings_model)
@@ -102,7 +102,7 @@ class TestSettingsService(TestCase):
     def test_get_template_settings_model_with_no_url_material_store_settings__then_empty_material_store_settings(self,
                                                                                                                  yaml_mock, requests_mock):
         yaml_mock.return_value = {'material-store': {
-            'environment': {'prod': {'enabled': True}}}}
+            'environment': {'prod': {'enabled': True, 'healthcheck_url': 'https://test.material.store.mr-beam.org/api/healthcheck'}}}}
         settings_model = self._settings_service.get_template_settings_model(MrBeamModel.DREAMCUT_S.value)
         self._validate_settings_model(settings_model)
         self._validate_empty_material_store_settings(settings_model)
@@ -112,7 +112,17 @@ class TestSettingsService(TestCase):
     def test_get_template_settings_model_with_no_enabled_material_store_settings__then_empty_material_store_settings(
             self, yaml_mock, requests_mock):
         yaml_mock.return_value = {'material-store': {
-            'environment': {'prod': {'url': 'https://test.material.store.mr-beam.org'}}}}
+            'environment': {'prod': {'url': 'https://test.material.store.mr-beam.org', 'healthcheck_url': 'https://test.material.store.mr-beam.org/api/healthcheck'}}}}
+        settings_model = self._settings_service.get_template_settings_model(MrBeamModel.DREAMCUT_S.value)
+        self._validate_settings_model(settings_model)
+        self._validate_empty_material_store_settings(settings_model)
+
+    @patch('octoprint_mrbeam.services.settings_service.requests.get')
+    @patch('octoprint_mrbeam.services.settings_service.yaml.load')
+    def test_get_template_settings_model_with_no_healthcheck_url_material_store_settings__then_empty_material_store_settings(
+            self, yaml_mock, requests_mock):
+        yaml_mock.return_value = {'material-store': {
+            'environment': {'prod': {'enabled': True, 'url': 'https://test.material.store.mr-beam.org'}}}}
         settings_model = self._settings_service.get_template_settings_model(MrBeamModel.DREAMCUT_S.value)
         self._validate_settings_model(settings_model)
         self._validate_empty_material_store_settings(settings_model)
@@ -121,11 +131,12 @@ class TestSettingsService(TestCase):
     @patch('octoprint_mrbeam.services.settings_service.yaml.load')
     def test_get_template_settings_model_with_correct_material_store_settings__then_valid_settings(self, yaml_mock, requests_mock):
         yaml_mock.return_value = {'material-store': {
-            'environment': {'prod': {'url': 'https://test.material.store.mr-beam.org', 'enabled': True}}}}
+            'environment': {'prod': {'url': 'https://test.material.store.mr-beam.org', 'enabled': True, 'healthcheck_url': 'https://test.material.store.mr-beam.org/api/healthcheck'}}}}
         settings_model = self._settings_service.get_template_settings_model(MrBeamModel.DREAMCUT_S.value)
         self._validate_settings_model(settings_model)
         self.assertEquals(settings_model.material_store.url, 'https://test.material.store.mr-beam.org')
         self.assertEquals(settings_model.material_store.enabled, True)
+        self.assertEquals(settings_model.material_store.healthcheck_url, 'https://test.material.store.mr-beam.org/api/healthcheck')
 
     def test_get_environment_from_settings_with_none__then_stable(self):
         environment = settings_service.get_environment_enum_from_plugin_settings(None)
@@ -192,5 +203,7 @@ class TestSettingsService(TestCase):
         self.assertIsNotNone(settings_model.material_store)
         self.assertIsNotNone(settings_model.material_store.enabled)
         self.assertIsNotNone(settings_model.material_store.url)
+        self.assertIsNotNone(settings_model.material_store.healthcheck_url)
         self.assertEquals(settings_model.material_store.enabled, False)
         self.assertEquals(settings_model.material_store.url, "")
+        self.assertEquals(settings_model.material_store.healthcheck_url, "")


### PR DESCRIPTION
SW-1931 Add healthcheck_url to the material store model
 
SW-1931 Add healthcheck_url to the settings service

SW-1931 Remove info logging
 
SW-1931 Add and modify unit tests
 
SW-1931 Modify material store HEAD call to use the healthcheck API
 
SW-1931 Fix a postMessage console error
 
SW-1931 Load design store once and not on every title item click

SW-1931 Initialize variable at the beginning of the method

SW-1931 Modify design store template

SW-1931 Add design store loading spinner styling

SW-1931 Fix bug

SW-1931 Move the design store template into the tabs folder

SW-1931 Lazy load the design store

SW-1931 Modify design store initialization logic
This change will show the network issues page if the device is offline. However, this will not change if the device gets online until the user refreshes the page.