### PR TITLE
SW-2312 SVG text not being lasered

### DIFF
--- a/octoprint_mrbeam/static/js/working_area.js
+++ b/octoprint_mrbeam/static/js/working_area.js
@@ -2970,6 +2970,8 @@ $(function () {
                         "polyline",
                         "polygon",
                         "path",
+                        "text",
+                        "tspan"
                     ].indexOf(e.type) >= 0
                 ) {
                     var fill = e.attr("fill");

--- a/octoprint_mrbeam/static/js/working_area.js
+++ b/octoprint_mrbeam/static/js/working_area.js
@@ -2969,7 +2969,6 @@ $(function () {
                         "line",
                         "polyline",
                         "polygon",
-                        "path",
                         "text",
                         "tspan"
                     ].indexOf(e.type) >= 0


### PR DESCRIPTION
SW-2312 Add text and tspan tags to be checked if filled

This will check the filling for the text and tspan tags in order to add the engraving tile in the working area designs list and the engraving parameters section. This will also allow the engraving method to be enabled if only filled text is found in the final SVG.