### PR TITLE
SW-2530 add correction factor limit and max intensity value to laserhead profile

### DIFF
--- a/octoprint_mrbeam/__init__.py
+++ b/octoprint_mrbeam/__init__.py
@@ -188,6 +188,9 @@ class MrBeamPlugin(
         self._device_series = self._device_info.get_series()
         self.called_hosts = []
 
+        self._iobeam_connected = False
+        self._laserhead_ready = False
+
         # Create the ``laserCutterProfileManager`` early to inject into the ``Laser``
         # See ``laser_factory``
         self.laserCutterProfileManager = laserCutterProfileManager(
@@ -224,6 +227,10 @@ class MrBeamPlugin(
         # listens to StartUp event to start counting boot time grace period
         self._event_bus.subscribe(
             OctoPrintEvents.STARTUP, self._start_boot_grace_period_thread
+        )
+        self._event_bus.subscribe(IoBeamEvents.CONNECT, self._on_iobeam_connect)
+        self._event_bus.subscribe(
+            MrBeamEvents.LASER_HEAD_READ, self._on_laserhead_ready
         )
 
         self.start_time_ntp_timer()
@@ -284,6 +291,45 @@ class MrBeamPlugin(
         self._connectivity_checker = ConnectivityChecker(self)
 
         self._do_initial_log()
+
+    def _on_iobeam_connect(self, *args, **kwargs):
+        """Called when the iobeam socket is connected.
+
+        Args:
+            *args:
+            **kwargs:
+
+        Returns:
+
+        """
+        self._logger.info("MrBeamPlugin on_iobeam_connected")
+        self._iobeam_connected = True
+        self._try_to_connect_laser()
+
+    def _on_laserhead_ready(self, *args, **kwargs):
+        """Called when the laserhead is ready.
+
+        Args:
+            *args:
+            **kwargs:
+
+        Returns:
+
+        """
+        self._logger.info("MrBeamPlugin on_laserhead_ready")
+        self._laserhead_ready = True
+        self._try_to_connect_laser()
+
+    def _try_to_connect_laser(self):
+        """
+        Tries to connect the laser if both iobeam and laserhead are ready and the laser is not connected yet.
+        """
+        if (
+            self._iobeam_connected
+            and self._laserhead_ready
+            and self._printer.is_closed_or_error()
+        ):
+            self._printer.connect()
 
     def _init_frontend_logger(self):
         handler = logging.handlers.RotatingFileHandler(
@@ -629,7 +675,7 @@ class MrBeamPlugin(
         self._logger.info("Mr Beam Plugin stopped.")
 
     def set_serial_setting(self):
-        self._settings.global_set(["serial", "autoconnect"], True)
+        self._settings.global_set(["serial", "autoconnect"], False)
         self._settings.global_set(["serial", "baudrate"], 115200)
         self._settings.global_set(["serial", "port"], "/dev/ttyAMA0")
 

--- a/octoprint_mrbeam/__init__.py
+++ b/octoprint_mrbeam/__init__.py
@@ -321,9 +321,7 @@ class MrBeamPlugin(
         self._try_to_connect_laser()
 
     def _try_to_connect_laser(self):
-        """
-        Tries to connect the laser if both iobeam and laserhead are ready and the laser is not connected yet.
-        """
+        """Tries to connect the laser if both iobeam and laserhead are ready and the laser is not connected yet."""
         if (
             self._iobeam_connected
             and self._laserhead_ready

--- a/octoprint_mrbeam/iobeam/laserhead_handler.py
+++ b/octoprint_mrbeam/iobeam/laserhead_handler.py
@@ -9,6 +9,9 @@ from octoprint_mrbeam.util.device_info import MODEL_MRBEAM_2_DC_S, MODEL_MRBEAM_
 
 LASERHEAD_MAX_TEMP_FALLBACK = 55.0
 LASERHEAD_MAX_DUST_FACTOR_FALLBACK = 3.0 # selected the highest factor
+LASERHEAD_MAX_CORRECTION_FACTOR_FALLBACK = 1
+LASERHEAD_MAX_INSTENSITY_INCLUDING_CORRECTION_FALLBACK = 1500
+
 LASERHEAD_STOCK_ID = 0
 LASERHEAD_S_ID = 1
 LASERHEAD_X_ID = 3
@@ -582,3 +585,74 @@ class LaserheadHandler(object):
         """
 
         return LASERHEAD_MAX_DUST_FACTOR_FALLBACK
+
+    @property
+    def current_laserhead_max_correction_factor(self):
+        """Return the current laser head max correction factor.
+
+        Returns:
+            float: Laser head max correction factor
+        """
+
+        current_laserhead_properties = self._get_laserhead_properties()
+
+        # Handle the exceptions
+        if ((isinstance(current_laserhead_properties, dict) is False) or
+                ("max_correction_factor" not in current_laserhead_properties) or
+                (isinstance(current_laserhead_properties["max_correction_factor"], float) is False)):
+            # Apply fallback
+            self._logger.debug("Current laserhead properties: {}".format(current_laserhead_properties))
+            self._logger.exception(
+                "Current Laserhead max correction factor couldn't be retrieved, fallback to the factor value of: {}".format(
+                    self.default_laserhead_max_correction_factor))
+            return self.default_laserhead_max_correction_factor
+        # Reaching here means, everything looks good
+        self._logger.debug(
+            "Current Laserhead max correction factor:{}".format(current_laserhead_properties["max_correction_factor"]))
+        return current_laserhead_properties["max_correction_factor"]
+
+    @property
+    def default_laserhead_max_correction_factor(self):
+        """Default max correction factor for laser head. To be used by other modules at init time.
+
+        Returns:
+            float: Laser head default max correction factor
+        """
+        return LASERHEAD_MAX_CORRECTION_FACTOR_FALLBACK
+
+    @property
+    def current_laserhead_max_intensity_including_correction(self):
+        """
+        Returns the current laser head max intensity after the power correction for laser head was calculated on top.
+
+        Returns:
+            int: Laser head max intensity including the correction factor
+        """
+
+        current_laserhead_properties = self._get_laserhead_properties()
+
+        # Handle the exceptions
+        if ((isinstance(current_laserhead_properties, dict) is False) or
+                ("max_intensity_including_correction" not in current_laserhead_properties) or
+                (isinstance(current_laserhead_properties["max_intensity_including_correction"], int) is False)):
+            # Apply fallback
+            self._logger.debug("Current laserhead properties: {}".format(current_laserhead_properties))
+            self._logger.exception(
+                "Current Laserhead max intensity including correction couldn't be retrieved, fallback to the factor value of: {}".format(
+                    self.default_laserhead_max_intensity_including_correction))
+            return self.default_laserhead_max_intensity_including_correction
+        # Reaching here means, everything looks good
+        self._logger.debug(
+            "Current Laserhead max intensity including correction:{}".format(current_laserhead_properties["max_intensity_including_correction"]))
+        return current_laserhead_properties["max_intensity_including_correction"]
+
+    @property
+    def default_laserhead_max_intensity_including_correction(self):
+        """
+        Default max intensity after the power correction for laser head was calculated on top. To be used by other modules at any time.
+
+        Returns:
+            int: Laser head default max intensity including the correction factor
+        """
+
+        return LASERHEAD_MAX_INSTENSITY_INCLUDING_CORRECTION_FALLBACK

--- a/octoprint_mrbeam/iobeam/laserhead_handler.py
+++ b/octoprint_mrbeam/iobeam/laserhead_handler.py
@@ -545,11 +545,10 @@ class LaserheadHandler(object):
             self._laserhead_properties = self._load_current_laserhead_properties()
             if self._laserhead_properties is not None:
                 self._laserhead_properties.update({'laserhead_id': laserhead_id})
+            self._logger.debug("_laserhead_properties - {}".format(self._laserhead_properties))
         else:
             self._logger.debug("no new laserhead_id -> return current laserhead_properties")
 
-        self._logger.debug(
-            "_laserhead_properties - {}".format(self._laserhead_properties))
         return self._laserhead_properties
 
     @property
@@ -566,7 +565,6 @@ class LaserheadHandler(object):
                 ("max_dust_factor" not in current_laserhead_properties) or
                 (isinstance(current_laserhead_properties["max_dust_factor"], float) is False)):
             # Apply fallback
-            self._logger.debug("Current laserhead properties: {}".format(current_laserhead_properties))
             self._logger.exception(
                 "Current Laserhead max dust factor couldn't be retrieved, fallback to the factor value of: {}".format(
                     self.default_laserhead_max_dust_factor))
@@ -601,7 +599,6 @@ class LaserheadHandler(object):
                 ("max_correction_factor" not in current_laserhead_properties) or
                 (isinstance(current_laserhead_properties["max_correction_factor"], float) is False)):
             # Apply fallback
-            self._logger.debug("Current laserhead properties: {}".format(current_laserhead_properties))
             self._logger.exception(
                 "Current Laserhead max correction factor couldn't be retrieved, fallback to the factor value of: {}".format(
                     self.default_laserhead_max_correction_factor))
@@ -636,7 +633,6 @@ class LaserheadHandler(object):
                 ("max_intensity_including_correction" not in current_laserhead_properties) or
                 (isinstance(current_laserhead_properties["max_intensity_including_correction"], int) is False)):
             # Apply fallback
-            self._logger.debug("Current laserhead properties: {}".format(current_laserhead_properties))
             self._logger.exception(
                 "Current Laserhead max intensity including correction couldn't be retrieved, fallback to the factor value of: {}".format(
                     self.default_laserhead_max_intensity_including_correction))

--- a/octoprint_mrbeam/printing/comm_acc2.py
+++ b/octoprint_mrbeam/printing/comm_acc2.py
@@ -2127,15 +2127,6 @@ class MachineCom(object):
 
             # Apply power correction factor and limit again (in case there is something wrong with the calculation of
             # the correction factor)
-            if self._power_correction_factor > self._max_correction_factor:
-                self._logger.debug(
-                    "Power correction factor higher as allowed max, will limit to max value - %s => %s",
-                    self._power_correction_factor,
-                    self._max_correction_factor,
-                )
-            self._power_correction_factor = min(
-                self._power_correction_factor, self._max_correction_factor
-            )
             self._current_intensity = int(
                 round(self._current_intensity * self._power_correction_factor)
             )

--- a/octoprint_mrbeam/printing/profiles/default.py
+++ b/octoprint_mrbeam/printing/profiles/default.py
@@ -18,13 +18,14 @@ profile = dict(
     # if set to onebutton, MR Beam 2 One Button to start laser is activated.
     start_method="onebutton",
     laser=dict(
-        max_temperature=55.0,   # deprecated, moved to iobeam.laserhead_handler in SW-1077
+        max_temperature=55.0,  # deprecated, moved to iobeam.laserhead_handler in SW-1077
         hysteresis_temperature=48.0,
         cooling_duration=25,  # if set to positive values: enables time based cooling resuming rather that per hysteresis_temperature
         intensity_factor=13,  # to get from 100% intesity to GCODE-intensity of 1300
         intensity_limit=1300,  # Limits intensity of ALL incomming G-Code commands (a correction factor is multiplied on top of this)
-        intensity_upper_bound=1500,  # Limits intensity of ALL G-Code commands even with correction factor to this upper bound
-        max_correction_factor=1.15,  # max value of the correction factor
+        # The following two values are now in the laserhead profile
+        # intensity_upper_bound=1500,  # Limits intensity of ALL G-Code commands even with correction factor to this upper bound
+        # max_correction_factor=1.15,  # max value of the correction factor
     ),
     dust=dict(extraction_limit=0.70, auto_mode_time=60),
     volume=dict(

--- a/octoprint_mrbeam/profiles/laserhead/laserhead_id_0.yaml
+++ b/octoprint_mrbeam/profiles/laserhead/laserhead_id_0.yaml
@@ -1,2 +1,4 @@
 max_temperature: 55.0
 max_dust_factor: 2.0
+max_correction_factor: 1.15
+max_intensity_including_correction: 1500

--- a/octoprint_mrbeam/profiles/laserhead/laserhead_id_1.yaml
+++ b/octoprint_mrbeam/profiles/laserhead/laserhead_id_1.yaml
@@ -1,2 +1,4 @@
 max_temperature: 59.0
 max_dust_factor: 3.0
+max_correction_factor: 1.15
+max_intensity_including_correction: 1500

--- a/octoprint_mrbeam/profiles/laserhead/laserhead_id_3.yaml
+++ b/octoprint_mrbeam/profiles/laserhead/laserhead_id_3.yaml
@@ -1,3 +1,5 @@
 #TODO SW-2322 update the values
 max_temperature: 65.0
 max_dust_factor: 6.0
+max_correction_factor: 1.23
+max_intensity_including_correction: 1600

--- a/tests/iobeam/test_laserhead_handler.py
+++ b/tests/iobeam/test_laserhead_handler.py
@@ -234,3 +234,99 @@ def test_is_current_used_lh_model_supported_invalid_laserhead_model(
         result = laserhead_handler.is_current_used_lh_model_supported()
         # Assert
         assert result is False
+
+
+@pytest.mark.parametrize(
+    "laserhead,expected_value",
+    [
+        (LASERHEAD_STOCK_ID, 1.15),
+        (LASERHEAD_S_ID, 1.15),
+        (LASERHEAD_X_ID, 1.23),
+        (None, 1),
+        (1000, 1),
+    ],
+    ids=[
+        "Laserhead Stock",
+        "Laserhead S",
+        "Laserhead X",
+        "None Laserhead",
+        "unknown Laserhead",
+    ],
+)
+def test_current_laserhead_max_correction_factor(
+    laserhead, expected_value, mrbeam_plugin
+):
+    # Arrange
+    with patch(
+        "octoprint_mrbeam.iobeam.laserhead_handler.LaserheadHandler.get_current_used_lh_model_id",
+        return_value=laserhead,
+    ):
+        laserhead_handler = LaserheadHandler(mrbeam_plugin)
+
+        # Act
+        max_correction_factor = (
+            laserhead_handler.current_laserhead_max_correction_factor
+        )
+
+        # Assert
+        assert max_correction_factor == expected_value
+
+
+def test_default_laserhead_max_correction_factor(mrbeam_plugin):
+    # Arrange
+    laserhead_handler = LaserheadHandler(mrbeam_plugin)
+
+    # Act
+    max_correction_factor = laserhead_handler.default_laserhead_max_correction_factor
+
+    # Assert
+    assert max_correction_factor == 1
+
+
+@pytest.mark.parametrize(
+    "laserhead,expected_value",
+    [
+        (LASERHEAD_STOCK_ID, 1500),
+        (LASERHEAD_S_ID, 1500),
+        (LASERHEAD_X_ID, 1600),
+        (None, 1500),
+        (1000, 1500),
+    ],
+    ids=[
+        "Laserhead Stock",
+        "Laserhead S",
+        "Laserhead X",
+        "None Laserhead",
+        "unknown Laserhead",
+    ],
+)
+def test_current_laserhead_max_intensity_including_correction(
+    laserhead, expected_value, mrbeam_plugin
+):
+    # Arrange
+    with patch(
+        "octoprint_mrbeam.iobeam.laserhead_handler.LaserheadHandler.get_current_used_lh_model_id",
+        return_value=laserhead,
+    ):
+        laserhead_handler = LaserheadHandler(mrbeam_plugin)
+
+        # Act
+        max_intensity = (
+            laserhead_handler.current_laserhead_max_intensity_including_correction
+        )
+
+        # Assert
+        assert max_intensity == expected_value
+
+
+def test_default_laserhead_max_intensity_including_correction(mrbeam_plugin):
+    # Arrange
+    laserhead_handler = LaserheadHandler(mrbeam_plugin)
+
+    # Act
+    max_intensity = (
+        laserhead_handler.default_laserhead_max_intensity_including_correction
+    )
+
+    # Assert
+    assert max_intensity == 1500

--- a/tests/printing/test_comm_acc2.py
+++ b/tests/printing/test_comm_acc2.py
@@ -1,0 +1,200 @@
+import pytest
+from mock.mock import patch, MagicMock
+
+from octoprint_mrbeam.printing.comm_acc2 import MachineCom
+
+
+@pytest.mark.parametrize(
+    "intensity_input,expected",
+    [
+        (700, 700),
+        (1300, 1300),
+        (1400, 1300),
+    ],
+    ids=[
+        "normal value",
+        "max value",
+        "over limit value",
+    ],
+)
+def test_send_command_correct_limit_intensity_input(
+    intensity_input, expected, mrbeam_plugin
+):
+    """
+    The intensity input value should be limited to 1300 [profile.laser.intensity_limit]
+    """
+    with patch(
+        "__builtin__._mrbeam_plugin_implementation", return_value=mrbeam_plugin
+    ) as mrbeam_plugin_mock:
+        mrbeam_plugin_mock.laserhead_handler = MagicMock(
+            current_laserhead_max_intensity_including_correction=1400,
+            current_laserhead_max_correction_factor=1,
+        )
+        with patch("octoprint.plugin.plugin_manager", return_value=MagicMock()):
+            machineCom = MachineCom()
+            machineCom._serial = MagicMock()
+
+            # Act
+            machineCom._sendCommand("G1 X1 F5000 S{}".format(intensity_input))
+
+            # Assert
+            machineCom._serial.write.assert_called_with(
+                "G1 X1 F5000 S{}".format(expected)
+            )
+
+
+def test_send_command_limit_correction_factor(mrbeam_plugin):
+    # Arrange
+    with patch(
+        "__builtin__._mrbeam_plugin_implementation", return_value=mrbeam_plugin
+    ) as mrbeam_plugin_mock:
+        mrbeam_plugin_mock.laserhead_handler = MagicMock(
+            current_laserhead_max_intensity_including_correction=1500,
+            current_laserhead_max_correction_factor=1.15,  # limit of the correction factor
+        )
+        with patch("octoprint.plugin.plugin_manager", return_value=MagicMock()):
+            machineCom = MachineCom()
+            machineCom._serial = MagicMock()
+            machineCom._current_lh_data = {
+                "correction_factor": 2
+            }  # current correction factor
+
+            # Act
+            machineCom._sendCommand("G1 X1 F5000 S1300")
+
+            # Assert
+            machineCom._serial.write.assert_called_with("G1 X1 F5000 S1495")
+
+
+def test_send_command_correct_intensity_under_max_intenstity(mrbeam_plugin):
+    # Arrange
+    with patch(
+        "__builtin__._mrbeam_plugin_implementation", return_value=mrbeam_plugin
+    ) as mrbeam_plugin_mock:
+        mrbeam_plugin_mock.laserhead_handler = MagicMock(
+            current_laserhead_max_intensity_including_correction=1500,
+            current_laserhead_max_correction_factor=2,  # use very high correction factor to go over max intensity
+        )
+        with patch("octoprint.plugin.plugin_manager", return_value=MagicMock()):
+            machineCom = MachineCom()
+            machineCom._serial = MagicMock()
+            machineCom._current_lh_data = {"correction_factor": 1.5}
+
+            # Act
+            machineCom._sendCommand("G1 X1 F5000 S1300")
+
+            # Assert
+            machineCom._serial.write.assert_called_with("G1 X1 F5000 S1500")
+
+
+def test_send_command_correct_intensity_correction_under_1(mrbeam_plugin):
+    # Arrange
+    with patch(
+        "__builtin__._mrbeam_plugin_implementation", return_value=mrbeam_plugin
+    ) as mrbeam_plugin_mock:
+        mrbeam_plugin_mock.laserhead_handler = MagicMock(
+            current_laserhead_max_intensity_including_correction=1500,
+            current_laserhead_max_correction_factor=1.15,  # use very high correction factor to go over max intensity
+            get_correction_settings=MagicMock(
+                return_value={
+                    "correction_enabled": True,
+                    "correction_factor_override": None,
+                }
+            ),
+        )
+        with patch("octoprint.plugin.plugin_manager", return_value=MagicMock()):
+            machineCom = MachineCom()
+            machineCom._serial = MagicMock()
+            machineCom._current_lh_data = {
+                "correction_factor": 0.1
+            }  # use a value lower as min limit of 1
+
+            # Act
+            machineCom._sendCommand("G1 X1 F5000 S1300")
+
+            # Assert
+            machineCom._serial.write.assert_called_with("G1 X1 F5000 S1300")
+
+
+def test_send_command_correction_factor_override(mrbeam_plugin):
+    # Arrange
+    with patch(
+        "__builtin__._mrbeam_plugin_implementation", return_value=mrbeam_plugin
+    ) as mrbeam_plugin_mock:
+        mrbeam_plugin_mock.laserhead_handler = MagicMock(
+            current_laserhead_max_intensity_including_correction=1800,
+            current_laserhead_max_correction_factor=1.4,  # use very high correction factor to go over max intensity
+            get_correction_settings=MagicMock(
+                return_value={
+                    "correction_enabled": True,
+                    "correction_factor_override": 1.3,  # override the correction factor
+                }
+            ),
+        )
+        with patch("octoprint.plugin.plugin_manager", return_value=MagicMock()):
+            machineCom = MachineCom()
+            machineCom._serial = MagicMock()
+            machineCom._current_lh_data = {
+                "correction_factor": 1.4
+            }  # this value should be ignored and the correction_factor_override used instead
+
+            # Act
+            machineCom._sendCommand("G1 X1 F5000 S1300")
+
+            # Assert
+            machineCom._serial.write.assert_called_with("G1 X1 F5000 S1690")
+
+
+def test_send_command_correction_disabled_factor_override(mrbeam_plugin):
+    # Arrange
+    with patch(
+        "__builtin__._mrbeam_plugin_implementation", return_value=mrbeam_plugin
+    ) as mrbeam_plugin_mock:
+        mrbeam_plugin_mock.laserhead_handler = MagicMock(
+            current_laserhead_max_intensity_including_correction=1800,
+            current_laserhead_max_correction_factor=1.4,  # use very high correction factor to go over max intensity
+            get_correction_settings=MagicMock(
+                return_value={
+                    "correction_enabled": False,  # correction disabled
+                    "correction_factor_override": 1.3,  # this factor should not be used as it is disabled
+                }
+            ),
+        )
+        with patch("octoprint.plugin.plugin_manager", return_value=MagicMock()):
+            machineCom = MachineCom()
+            machineCom._serial = MagicMock()
+
+            # Act
+            machineCom._sendCommand("G1 X1 F5000 S1300")
+
+            # Assert
+            machineCom._serial.write.assert_called_with("G1 X1 F5000 S1300")
+
+
+def test_send_command_correction_disabled_factor_override(mrbeam_plugin):
+    # Arrange
+    with patch(
+        "__builtin__._mrbeam_plugin_implementation", return_value=mrbeam_plugin
+    ) as mrbeam_plugin_mock:
+        mrbeam_plugin_mock.laserhead_handler = MagicMock(
+            current_laserhead_max_intensity_including_correction=1800,
+            current_laserhead_max_correction_factor=1.4,  # use very high correction factor to go over max intensity
+            get_correction_settings=MagicMock(
+                return_value={
+                    "correction_enabled": False,  # correction disabled
+                    "correction_factor_override": None,  # Don't override
+                }
+            ),
+        )
+        with patch("octoprint.plugin.plugin_manager", return_value=MagicMock()):
+            machineCom = MachineCom()
+            machineCom._serial = MagicMock()
+            machineCom._current_lh_data = {
+                "correction_factor": 1.4
+            }  # this factor should not be used as it is disabled
+
+            # Act
+            machineCom._sendCommand("G1 X1 F5000 S1300")
+
+            # Assert
+            machineCom._serial.write.assert_called_with("G1 X1 F5000 S1300")


### PR DESCRIPTION
- add max_correction_factor and max_intensity_including_correction to laserhead profiles
- disable autoconnect to laser
- connect to laser after iobeam is connected and laserhead data is received