### PR TITLE
SW-342 fix failing update for legacy image

### DIFF
--- a/octoprint_mrbeam/scripts/update_script.py
+++ b/octoprint_mrbeam/scripts/update_script.py
@@ -215,7 +215,6 @@ def install_wheels(install_queue):
         pip_args = [
             "install",
             "--disable-pip-version-check",
-            "--upgrade",  # Upgrade all specified packages to the newest available version. The handling of dependencies depends on the upgrade-strategy used.
             "--find-links={}".format(
                 tmp_folder
             ),  # If a URL or path to an html file, then parse for links to archives such as sdist (.tar.gz) or wheel (.whl) files. If a local path or file:// URL that's a directory, then look for archives in the directory listing. Links to VCS project URLs are not supported.


### PR DESCRIPTION
remove --upgrade option in pip install to not upgrade dependencies version with version range