### PR TITLE
SW-3425 fix missing typing

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,7 @@ plugin_requires = [
     "pyyaml",
     "enum34",
     "python-statemachine==1.0.3",
+    "typing",  # dependency of python-statemachine
     picamera,
 ]
 


### PR DESCRIPTION
typing is a dependency of python-statemachine but not installed on a legacy device, this fixes this issue