### PR TITLE
SW-3291 Quick text fonts are not loaded causing bounding box discrepancies

### DIFF
--- a/octoprint_mrbeam/static/js/app/helpers/util.js
+++ b/octoprint_mrbeam/static/js/app/helpers/util.js
@@ -107,7 +107,7 @@ $(function () {
 
     let _checkDimensionsAndThrowError = function (w, h, errorMessage) {
         if (w === 0 || h === 0) {
-            console.error(errorMessage, image);
+            console.error(errorMessage);
             throw new Error(errorMessage);
         }
     };

--- a/octoprint_mrbeam/static/js/app/helpers/util.js
+++ b/octoprint_mrbeam/static/js/app/helpers/util.js
@@ -40,7 +40,9 @@ $(function () {
         includesQuickText = false
     ) {
         // Load an image and wait for it to be loaded
-        const image = await loadImagePromise(url);
+        const image = await loadImagePromise(url).catch((error) => {
+            console.error("Error caught in loadImagePromise:", error);
+        });
 
         // Get the image dimensions
         let x = 0;
@@ -80,7 +82,12 @@ $(function () {
             h,
             pxPerMM,
             includesQuickText
-        );
+        ).catch((error) => {
+            console.error(
+                "Error caught in _handleAndDrawImageOnCanvas:",
+                error
+            );
+        });
 
         // Get PNG from canvas
         const png = canvas.toDataURL("image/png");

--- a/octoprint_mrbeam/static/js/app/helpers/util.js
+++ b/octoprint_mrbeam/static/js/app/helpers/util.js
@@ -147,9 +147,13 @@ $(function () {
         return new Promise((resolve) => {
             if (includesQuickText) {
                 setTimeout(() => {
+                    // Log image dimensions
+                    console.info(
+                        `Clear canvas: x=${x}, y=${y}, canvas.width=${updatedCanvas.canvas.width}, canvas.height=${updatedCanvas.canvas.height}`
+                    );
                     updatedCanvas.ctx.clearRect(
-                        0,
-                        0,
+                        x,
+                        y,
                         updatedCanvas.canvas.width,
                         updatedCanvas.canvas.height
                     );
@@ -189,7 +193,7 @@ $(function () {
         }
 
         // Log image dimensions
-        console.info(`c.drawImage ${x}, ${y}, ${w}, ${h}`);
+        console.info(`Draw image: x=${x}, y=${y}, w=${w}, h=${h}`);
 
         // Draw image on canvas
         ctx.drawImage(image, x, y, w, h, 0, 0, canvas.width, canvas.height);

--- a/octoprint_mrbeam/static/js/app/helpers/util.js
+++ b/octoprint_mrbeam/static/js/app/helpers/util.js
@@ -147,7 +147,7 @@ $(function () {
         return new Promise((resolve) => {
             if (includesQuickText) {
                 setTimeout(() => {
-                    // Log image dimensions
+                    // Clear canvas
                     console.info(
                         `Clear canvas: x=${x}, y=${y}, canvas.width=${updatedCanvas.canvas.width}, canvas.height=${updatedCanvas.canvas.height}`
                     );
@@ -192,10 +192,8 @@ $(function () {
             ctx.fillRect(0, 0, canvas.width, canvas.height);
         }
 
-        // Log image dimensions
-        console.info(`Draw image: x=${x}, y=${y}, w=${w}, h=${h}`);
-
         // Draw image on canvas
+        console.info(`Draw image: x=${x}, y=${y}, w=${w}, h=${h}`);
         ctx.drawImage(image, x, y, w, h, 0, 0, canvas.width, canvas.height);
 
         // Return canvas

--- a/octoprint_mrbeam/static/js/app/helpers/util.js
+++ b/octoprint_mrbeam/static/js/app/helpers/util.js
@@ -144,6 +144,7 @@ $(function () {
         // Check if quickText is included and wait for it to be redrawn
         // The reason behind this is that quickText fonts might not be loaded yet
         // So we wait a bit and redraw the image on the canvas to make sure the font is loaded
+        // ToDo: Add the bug detection into analytics (SW-3919)
         return new Promise((resolve) => {
             if (includesQuickText) {
                 setTimeout(() => {

--- a/octoprint_mrbeam/static/js/app/helpers/util.js
+++ b/octoprint_mrbeam/static/js/app/helpers/util.js
@@ -77,7 +77,7 @@ $(function () {
         );
 
         // Handle and draw image on canvas
-        let canvasDrawingOutcome = await _handleAndDrawImageOnCanvas(
+        let canvas = await _handleAndDrawImageOnCanvas(
             whiteBG,
             image,
             x,
@@ -94,21 +94,15 @@ $(function () {
         });
 
         // Get PNG from canvas
-        const png = canvasDrawingOutcome.canvas.toDataURL("image/png");
+        const png = canvas.toDataURL("image/png");
 
         // Get analysis from canvas
-        const analysis = getCanvasAnalysis(canvasDrawingOutcome.canvas);
+        const analysis = getCanvasAnalysis(canvas);
 
         // Remove canvas
-        canvasDrawingOutcome.canvas.remove();
+        canvas.remove();
 
-        return {
-            dataUrl: png,
-            bbox: bbox,
-            analysis: analysis,
-            isFontLoadingIntoCanvasIssueDetected:
-                canvasDrawingOutcome.isFontLoadingIntoCanvasIssueDetected,
-        };
+        return { dataUrl: png, bbox: bbox, analysis: analysis };
     };
 
     let _checkDimensionsAndThrowError = function (w, h, errorMessage) {
@@ -177,31 +171,12 @@ $(function () {
                             h
                         );
 
-                    // Check if the font loading into canvas issue is present
-                    const isFontLoadingIntoCanvasIssueDetected =
-                        _isFontLoadingIntoCanvasIssueDetected(
-                            updatedCanvas.canvas,
-                            quickTextUpdatedCanvasAfterDelay.canvas
-                        );
-
                     // resolve promise
-                    resolve({
-                        canvas: quickTextUpdatedCanvasAfterDelay.canvas,
-                        isFontLoadingIntoCanvasIssueDetected:
-                            isFontLoadingIntoCanvasIssueDetected,
-                    });
+                    resolve(quickTextUpdatedCanvasAfterDelay.canvas);
                 }, QUICK_TEXT_FONT_LOAD_TIMEOUT);
             } else {
-                const isFontLoadingIntoCanvasIssueDetected = {
-                    result: false,
-                    payload: null,
-                };
                 // resolve promise
-                resolve({
-                    canvas: updatedCanvas.canvas,
-                    isFontLoadingIntoCanvasIssueDetected:
-                        isFontLoadingIntoCanvasIssueDetected,
-                });
+                resolve(updatedCanvas.canvas);
             }
         });
     };
@@ -228,35 +203,6 @@ $(function () {
 
         // Return canvas
         return { canvas, ctx };
-    };
-
-    let _isFontLoadingIntoCanvasIssueDetected = function (
-        firstCanvas,
-        secondCanvas
-    ) {
-        // Get PNG data URLs from the canvases
-        const dataURL1 = firstCanvas.toDataURL("image/png");
-        const dataURL2 = secondCanvas.toDataURL("image/png");
-
-        // Compare the data URLs
-        if (dataURL1 !== dataURL2) {
-            console.error(
-                "Font loading into canvas issue detected! The data URLs are not the same!"
-            );
-            const payload = {
-                drawCanvasResult: dataURL1,
-                redrawCanvasResult: dataURL2,
-            };
-            return {
-                result: true,
-                payload: payload,
-            };
-        } else {
-            return {
-                result: false,
-                payload: null,
-            };
-        }
     };
 
     getCanvasAnalysis = function (canvas) {

--- a/octoprint_mrbeam/static/js/app/helpers/util.js
+++ b/octoprint_mrbeam/static/js/app/helpers/util.js
@@ -2,6 +2,10 @@ $(function () {
     /**
      * https://stackoverflow.com/a/7616484
      */
+
+    // Even in slow 3g throttling mode, the font is loaded within 40ms
+    const QUICK_TEXT_FONT_LOAD_TIMEOUT = 50; // ms
+
     String.prototype.hashCode = function () {
         let hash = 0,
             i,
@@ -161,7 +165,7 @@ $(function () {
                             h
                         );
                     resolve(quickTextUpdatedCanvasAfterDelay.canvas);
-                }, 100);
+                }, QUICK_TEXT_FONT_LOAD_TIMEOUT);
             } else {
                 resolve(updatedCanvas.canvas);
             }

--- a/octoprint_mrbeam/static/js/app/helpers/util.js
+++ b/octoprint_mrbeam/static/js/app/helpers/util.js
@@ -157,6 +157,8 @@ $(function () {
                         updatedCanvas.canvas.width,
                         updatedCanvas.canvas.height
                     );
+
+                    // Redraw canvas after delay
                     let quickTextUpdatedCanvasAfterDelay =
                         _checkWhiteBgAndDrawImage(
                             updatedCanvas.canvas,
@@ -168,9 +170,12 @@ $(function () {
                             w,
                             h
                         );
+
+                    // resolve promise
                     resolve(quickTextUpdatedCanvasAfterDelay.canvas);
                 }, QUICK_TEXT_FONT_LOAD_TIMEOUT);
             } else {
+                // resolve promise
                 resolve(updatedCanvas.canvas);
             }
         });

--- a/octoprint_mrbeam/static/js/app/helpers/util.js
+++ b/octoprint_mrbeam/static/js/app/helpers/util.js
@@ -144,7 +144,7 @@ $(function () {
         // Check if quickText is included and wait for it to be redrawn
         // The reason behind this is that quickText fonts might not be loaded yet
         // So we wait a bit and redraw the image on the canvas to make sure the font is loaded
-        // ToDo: Add the bug detection into analytics (SW-3919)
+        // TODO: Add the bug detection into analytics (SW-3919)
         return new Promise((resolve) => {
             if (includesQuickText) {
                 setTimeout(() => {

--- a/octoprint_mrbeam/static/js/app/snap-plugins/render-fills.js
+++ b/octoprint_mrbeam/static/js/app/snap-plugins/render-fills.js
@@ -274,7 +274,7 @@ Snap.plugin(function (Snap, Element, Paper, global) {
             return Promise.resolve(elem);
         }
 
-        let prom = url2png(url).then((result) => {
+        let prom = generatePNGFromURL(url).then((result) => {
             elem.attr("href", result.dataUrl);
             return elem;
         });
@@ -344,8 +344,9 @@ Snap.plugin(function (Snap, Element, Paper, global) {
                 h,
                 fontDeclarations
             );
-            url2png(svgDataUrl, pxPerMM, bboxMM, true).then((result) => {
-                const size = getDataUriSize(result.dataUrl);
+            generatePNGFromURL(svgDataUrl, pxPerMM, bboxMM, true).then(
+                (result) => {
+                    const size = getDataUriSize(result.dataUrl);
 
                 if (MRBEAM_DEBUG_RENDERING) {
                     console.info(
@@ -549,7 +550,7 @@ Snap.plugin(function (Snap, Element, Paper, global) {
     //        return promise;
     //    };
 
-    // TODO use url2png, simplify, check if necessary
+    // TODO use generatePNGFromURL, simplify, check if necessary
     Element.prototype.renderJobTimeEstimationPNG = function (
         wPT,
         hPT,

--- a/octoprint_mrbeam/static/js/app/snap-plugins/render-fills.js
+++ b/octoprint_mrbeam/static/js/app/snap-plugins/render-fills.js
@@ -348,38 +348,39 @@ Snap.plugin(function (Snap, Element, Paper, global) {
                 (result) => {
                     const size = getDataUriSize(result.dataUrl);
 
-                if (MRBEAM_DEBUG_RENDERING) {
-                    console.info(
-                        "MRBEAM_DEBUG_RENDERING",
-                        result.dataUrl,
-                        result.bbox
-                    );
-                    const img = elem.paper.image(
-                        result.dataUrl,
-                        result.bbox.x,
-                        result.bbox.y,
-                        result.bbox.w,
-                        result.bbox.h
-                    );
-                    img.attr("opacity", 0.6);
-                    img.click(function () {
-                        img.remove();
-                    });
-                    const r = elem.paper.rect(result.bbox).attr({
-                        fill: "none",
-                        stroke: "#aa00aa",
-                        strokeWidth: 2,
-                    });
-                    setTimeout(() => r.remove(), 5000);
-                }
+                    if (MRBEAM_DEBUG_RENDERING) {
+                        console.info(
+                            "MRBEAM_DEBUG_RENDERING",
+                            result.dataUrl,
+                            result.bbox
+                        );
+                        const img = elem.paper.image(
+                            result.dataUrl,
+                            result.bbox.x,
+                            result.bbox.y,
+                            result.bbox.w,
+                            result.bbox.h
+                        );
+                        img.attr("opacity", 0.6);
+                        img.click(function () {
+                            img.remove();
+                        });
+                        const r = elem.paper.rect(result.bbox).attr({
+                            fill: "none",
+                            stroke: "#aa00aa",
+                            strokeWidth: 2,
+                        });
+                        setTimeout(() => r.remove(), 5000);
+                    }
 
-                resolve({
-                    dataUrl: result.dataUrl,
-                    size: size,
-                    bbox: bboxMM,
-                    analysis: result.analysis,
-                });
-            });
+                    resolve({
+                        dataUrl: result.dataUrl,
+                        size: size,
+                        bbox: bboxMM,
+                        analysis: result.analysis,
+                    });
+                }
+            );
         });
         return prom;
     };

--- a/octoprint_mrbeam/static/js/app/snap-plugins/render-fills.js
+++ b/octoprint_mrbeam/static/js/app/snap-plugins/render-fills.js
@@ -119,7 +119,11 @@ Snap.plugin(function (Snap, Element, Paper, global) {
                         lastOverlap = j;
                     }
                 }
+
+                // Update cluster if it includes QuickText elements
+                updateClusterIfItContainsQuickText(cluster);
             }
+
             clusters = clusters.filter((c) => c !== null);
             if (lastOverlap === -1) {
                 // create new cluster
@@ -722,5 +726,17 @@ Snap.plugin(function (Snap, Element, Paper, global) {
             }
         }
         return [];
+    }
+
+    function updateClusterIfItContainsQuickText(cluster) {
+        cluster.elements.forEach((element) => {
+            let classListArray = Array.from(element.node.classList);
+            if (
+                classListArray.includes("straightText") ||
+                classListArray.includes("curvedText")
+            ) {
+                cluster.includesQuickText = true;
+            }
+        });
     }
 });

--- a/octoprint_mrbeam/static/js/app/snap-plugins/render-fills.js
+++ b/octoprint_mrbeam/static/js/app/snap-plugins/render-fills.js
@@ -344,7 +344,8 @@ Snap.plugin(function (Snap, Element, Paper, global) {
                 h,
                 fontDeclarations
             );
-            generatePNGFromURL(svgDataUrl, pxPerMM, bboxMM, true).then(
+            // includesQuickText is always true here as this method is only used on QuickText elements
+            generatePNGFromURL(svgDataUrl, pxPerMM, bboxMM, true, true).then(
                 (result) => {
                     const size = getDataUriSize(result.dataUrl);
 

--- a/octoprint_mrbeam/static/js/app/view-models/working-area.js
+++ b/octoprint_mrbeam/static/js/app/view-models/working-area.js
@@ -3292,9 +3292,13 @@ $(function () {
             if (fillAreas) {
                 let pngs = await Promise.all(
                     clusters.map((c) =>
-                        url2png(c.svgDataUrl, pxPerMM, c.bbox).then(function (
-                            rasterResult
-                        ) {
+                        generatePNGFromURL(
+                            c.svgDataUrl,
+                            pxPerMM,
+                            c.bbox,
+                            false,
+                            c?.includesQuickText
+                        ).then(function (rasterResult) {
                             const fillImage = svg.image(
                                 rasterResult.dataUrl,
                                 c.bbox.x,

--- a/octoprint_mrbeam/static/js/app/view-models/working-area.js
+++ b/octoprint_mrbeam/static/js/app/view-models/working-area.js
@@ -3299,19 +3299,6 @@ $(function () {
                             false,
                             c?.includesQuickText
                         ).then(function (rasterResult) {
-                            // send analytics if font loading into canvas issue is detected
-                            if (
-                                rasterResult
-                                    .isFontLoadingIntoCanvasIssueDetected.result
-                            ) {
-                                self._sendAnalytics(
-                                    "font_loading_into_canvas_issue_detected__",
-                                    rasterResult
-                                        .isFontLoadingIntoCanvasIssueDetected
-                                        .payload
-                                );
-                            }
-
                             const fillImage = svg.image(
                                 rasterResult.dataUrl,
                                 c.bbox.x,

--- a/octoprint_mrbeam/static/js/app/view-models/working-area.js
+++ b/octoprint_mrbeam/static/js/app/view-models/working-area.js
@@ -3299,6 +3299,19 @@ $(function () {
                             false,
                             c?.includesQuickText
                         ).then(function (rasterResult) {
+                            // send analytics if font loading into canvas issue is detected
+                            if (
+                                rasterResult
+                                    .isFontLoadingIntoCanvasIssueDetected.result
+                            ) {
+                                self._sendAnalytics(
+                                    "font_loading_into_canvas_issue_detected__",
+                                    rasterResult
+                                        .isFontLoadingIntoCanvasIssueDetected
+                                        .payload
+                                );
+                            }
+
                             const fillImage = svg.image(
                                 rasterResult.dataUrl,
                                 c.bbox.x,


### PR DESCRIPTION
SW-3291 Update cluster if it includes quickText elements
SW-3291 Refactor url2png and redraw canvas if url contains quickText elements
SW-3291 Refactor render-fills.js
SW-3291 Add quickText font load timeout as a constant
SW-3291 Add includesQuickText parameter to all generatePNGFromURL methods used on QuickText elements
SW-3291 Add log messages on draw and clear canvas